### PR TITLE
Apply Copilot suggestions from PR #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "node --test --no-warnings 'src/**/*.test.ts'",
-    "test:interop": "node --test --no-warnings 'test_interop/test_*.ts'",
+    "test:interop": "node --test --test-concurrency=1 --no-warnings 'test_interop/test_*.ts'",
     "test:vector": "node --test --no-warnings 'test_vectors/**/*.test.ts'",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/test_interop/keripy.ts
+++ b/test_interop/keripy.ts
@@ -39,6 +39,9 @@ export class KERIPy {
         output += message;
       });
       child.stderr.on("data", (d: Buffer) => this.log(d.toString()));
+      child.on("error", (err) => {
+        reject(err);
+      });
       child.on("close", (code) => {
         if (code !== 0) {
           reject(new Error(`kli ${args[0]} failed`));
@@ -167,8 +170,15 @@ export class KERIPy {
         "-T",
         String(opts.tcp),
       ];
-      this.log(`kli ${args.map((arg) => (arg.includes(" ") ? `"${arg}"` : arg)).join(" ")}`);
+      const command = `kli ${args.map((arg) => (arg.includes(" ") ? `"${arg}"` : arg)).join(" ")}`;
+      this.log(command);
       const child = spawn(KLI, args, { signal: opts.signal });
+      child.on("error", (error: Error) => {
+        this.log(`failed to start ${command}: ${error.message}`);
+      });
+      child.on("exit", (code, signal) => {
+        this.log(`witness process exited with code=${code ?? "null"} signal=${signal ?? "null"}`);
+      });
       child.stdout.on("data", (d: Buffer) => {
         for (const line of d.toString().split("\n").filter(Boolean)) {
           this.log(line);

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -56,7 +56,20 @@ export async function startKerijsWitness(opts: { port?: number; signal?: AbortSi
 
   const server = createServer(listener);
 
-  await new Promise<void>((resolve) => server.listen(port, resolve));
+  await new Promise<void>((resolve, reject) => {
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    const onError = (err: Error) => {
+      server.off("listening", onListening);
+      reject(err);
+    };
+
+    server.once("listening", onListening);
+    server.once("error", onError);
+    server.listen(port);
+  });
 
   opts.signal?.addEventListener("abort", () => {
     server.close();
@@ -86,16 +99,22 @@ export async function startKeripyWitness(
 
   const oobiUrl = `${url}/oobi`;
   const deadline = Date.now() + 30000;
+  let ready = false;
   while (Date.now() < deadline) {
     try {
       const response = await fetch(oobiUrl);
       if (response.ok || response.status === 404) {
+        ready = true;
         break;
       }
     } catch {
       // not ready yet
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  if (!ready) {
+    throw new Error(`KERIpy witness at ${oobiUrl} did not become reachable within 30s`);
   }
 
   return { aid, url, oobi: oobiUrl };


### PR DESCRIPTION
## Summary

Applies the concrete code suggestions left by Copilot on PR #15:

1. **`package.json`** — added `--test-concurrency=1` to `test:interop` script to prevent test races.
2. **`test_interop/utils.ts`** — fixed `server.listen()` in `startKerijsWitness` to reject the promise on an `'error'` event, not just silently hang.
3. **`test_interop/utils.ts`** — added a `ready` flag in `startKeripyWitness` so the function throws a descriptive error if the witness never becomes reachable within the 30 s deadline.
4. **`test_interop/keripy.ts`** — added an `'error'` listener to the `run()` child process so spawn failures are surfaced as rejections.
5. **`test_interop/keripy.ts`** — added `'error'` and `'exit'` listeners to the `witness.start()` child process for better diagnostics when the witness process fails to start or exits unexpectedly.

## Test plan

- [x] `npm run check` passes with no TypeScript errors
- [x] Run `npm run test:interop` against a live KERIpy demo to confirm interop tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)