### PR TITLE
Witness signature validation and multi-witness receipt merging

### DIFF
--- a/src/core/kawa.test.ts
+++ b/src/core/kawa.test.ts
@@ -11,7 +11,7 @@ import { sign } from "./sign.ts";
 test("returns witness indexed signature for single witness", async () => {
   const sigKey = generateKeyPair();
   const nextKey = generateKeyPair();
-  const witnessKey = generateKeyPair(undefined, { nonTransferable: true });
+  const witnessKey = generateKeyPair({ nonTransferable: true });
 
   const event = incept({
     signingKeys: [sigKey.publicKey],
@@ -51,8 +51,8 @@ test("returns witness indexed signature for single witness", async () => {
 test("rejects receipt with invalid witness signature", async () => {
   const sigKey = generateKeyPair();
   const nextKey = generateKeyPair();
-  const witnessKey = generateKeyPair(undefined, { nonTransferable: true });
-  const attackerKey = generateKeyPair(undefined, { nonTransferable: true });
+  const witnessKey = generateKeyPair({ nonTransferable: true });
+  const attackerKey = generateKeyPair({ nonTransferable: true });
 
   const event = incept({
     signingKeys: [sigKey.publicKey],

--- a/src/core/kawa.test.ts
+++ b/src/core/kawa.test.ts
@@ -76,5 +76,5 @@ test("rejects receipt with invalid witness signature", async () => {
     url: "http://witness.example",
   };
 
-  await assert.rejects(() => submitToWitnesses(event, [endpoint], fetchMock), /Invalid signature for key at index 0/);
+  await assert.rejects(() => submitToWitnesses(event, [endpoint], fetchMock), /Invalid witness signature from/);
 });

--- a/src/core/kawa.ts
+++ b/src/core/kawa.ts
@@ -1,60 +1,11 @@
-import { cesr, Indexer, Matter, Message, parse } from "../cesr/__main__.ts";
+import { cesr, Matter, Message } from "../cesr/__main__.ts";
 import type { KeyEventBody } from "./key-event.ts";
 import { MailboxClient } from "./mailbox-client.ts";
-import type { ReceiptEvent } from "./receipt-event.ts";
-import { verifyOrThrow } from "./verify.ts";
+import { WitnessClient } from "./witness-client.ts";
 
 export interface WitnessEndpoint {
   aid: string;
   url: string;
-}
-
-class WitnessClient {
-  #url: string;
-  #fetch: typeof globalThis.fetch;
-
-  constructor(url: string, fetch?: typeof globalThis.fetch) {
-    this.#url = url;
-    this.#fetch = fetch ?? globalThis.fetch;
-  }
-
-  async receipt(event: Message<KeyEventBody>): Promise<ReceiptEvent> {
-    const url = new URL("/receipts", this.#url);
-
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw new Error(`Invalid protocol: ${url}`);
-    }
-
-    const fetchResponse = await this.#fetch(url, {
-      method: "POST",
-      body: JSON.stringify(event.body),
-      headers: {
-        "Content-Type": "application/cesr+json",
-        "CESR-ATTACHMENT": event.attachments.text(),
-      },
-    });
-
-    if (!fetchResponse.ok || !fetchResponse.body) {
-      throw new Error(`Failed to submit event to witness: ${fetchResponse.status} ${fetchResponse.statusText}`);
-    }
-
-    for await (const incoming of parse(fetchResponse.body)) {
-      if (incoming.body.t === "rct" && incoming.body.d === event.body.d) {
-        for (const couple of incoming.attachments.NonTransReceiptCouples) {
-          const sig = Indexer.convert(Matter.parse(couple.sig), 0).text();
-          verifyOrThrow(event.raw, {
-            keys: [couple.prefix],
-            sigs: [sig],
-            threshold: "1",
-          });
-        }
-
-        return incoming as ReceiptEvent;
-      }
-    }
-
-    throw new Error(`No receipt returned from ${this.#url}`);
-  }
 }
 
 /**

--- a/src/core/key-event-log.test.ts
+++ b/src/core/key-event-log.test.ts
@@ -68,4 +68,84 @@ describe("KeyEventLog", () => {
     assert.equal(log.state.lastEvent.s, "1");
     assert.equal(log.state.lastEvent.d, "EIybyHwRGcth--_AiIO6SNN2-VSYZqezeEphEChn3XIM");
   });
+
+  describe("allowPartiallySigned", () => {
+    test("allows appending icp with no controller sigs", () => {
+      const key0 = generateKeyPair();
+      const key1 = generateKeyPair();
+      const event = incept({ signingKeys: [key0.publicKey], nextKeys: [key1.publicKeyDigest] });
+      const log = KeyEventLog.empty().append(new Message(event.body), { allowPartiallySigned: true });
+      assert.equal(log.state.lastEvent.s, "0");
+    });
+
+    test("still throws on cryptographically invalid controller sig", () => {
+      const key0 = generateKeyPair();
+      const key1 = generateKeyPair();
+      const wrongKey = generateKeyPair();
+      const event = incept({ signingKeys: [key0.publicKey], nextKeys: [key1.publicKeyDigest] });
+      const wrongSigs = sign(event, [wrongKey]);
+      assert.throws(
+        () =>
+          KeyEventLog.empty().append(new Message(event.body, { ControllerIdxSigs: wrongSigs }), {
+            allowPartiallySigned: true,
+          }),
+        { message: "Invalid signature for key at index 0" },
+      );
+    });
+  });
+
+  describe("allowPartiallyWitnessed", () => {
+    test("allows appending witnessed icp with no witness sigs", () => {
+      const key0 = generateKeyPair();
+      const key1 = generateKeyPair();
+      const witnessKey = generateKeyPair();
+      const event = incept({
+        signingKeys: [key0.publicKey],
+        nextKeys: [key1.publicKeyDigest],
+        wits: [witnessKey.publicKey],
+      });
+      const controllerSigs = sign(event, [key0]);
+      const log = KeyEventLog.empty().append(new Message(event.body, { ControllerIdxSigs: controllerSigs }), {
+        allowPartiallyWitnessed: true,
+      });
+      assert.equal(log.state.lastEvent.s, "0");
+    });
+
+    test("throws on missing witness sigs by default", () => {
+      const key0 = generateKeyPair();
+      const key1 = generateKeyPair();
+      const witnessKey = generateKeyPair();
+      const event = incept({
+        signingKeys: [key0.publicKey],
+        nextKeys: [key1.publicKeyDigest],
+        wits: [witnessKey.publicKey],
+      });
+      const controllerSigs = sign(event, [key0]);
+      assert.throws(() => KeyEventLog.empty().append(new Message(event.body, { ControllerIdxSigs: controllerSigs })), {
+        message: /Threshold not met/,
+      });
+    });
+
+    test("still throws on cryptographically invalid witness sig", () => {
+      const key0 = generateKeyPair();
+      const key1 = generateKeyPair();
+      const witnessKey = generateKeyPair();
+      const wrongWitnessKey = generateKeyPair();
+      const event = incept({
+        signingKeys: [key0.publicKey],
+        nextKeys: [key1.publicKeyDigest],
+        wits: [witnessKey.publicKey],
+      });
+      const controllerSigs = sign(event, [key0]);
+      const wrongWitnessSigs = sign(event, [wrongWitnessKey]);
+      assert.throws(
+        () =>
+          KeyEventLog.empty().append(
+            new Message(event.body, { ControllerIdxSigs: controllerSigs, WitnessIdxSigs: wrongWitnessSigs }),
+            { allowPartiallyWitnessed: true },
+          ),
+        { message: "Invalid signature for key at index 0" },
+      );
+    });
+  });
 });

--- a/src/core/key-event-log.ts
+++ b/src/core/key-event-log.ts
@@ -1,6 +1,13 @@
 import { Message, parse } from "../cesr/__main__.ts";
 import type { InceptEventBody, InteractEventBody, KeyEventBody, KeyState, RotateEventBody } from "./key-event.ts";
-import { verifyOrThrow } from "./verify.ts";
+import { verifySignaturesOrThrow, verifyThresholdOrThrow } from "./verify.ts";
+
+export interface AppendOptions {
+  /** Allow appending an event whose controller signatures don't meet the signing threshold. Individual signatures that are present must still be cryptographically valid. */
+  allowPartiallySigned?: boolean;
+  /** Allow appending an event whose witness signatures don't meet the backer threshold. Individual signatures that are present must still be cryptographically valid. */
+  allowPartiallyWitnessed?: boolean;
+}
 
 export type {
   InceptEventBody as InceptEvent,
@@ -22,21 +29,21 @@ export class KeyEventLog {
     return new KeyEventLog([], null);
   }
 
-  static from(events: Iterable<Message<KeyEventBody>>): KeyEventLog {
+  static from(events: Iterable<Message<KeyEventBody>>, options?: AppendOptions): KeyEventLog {
     let log = KeyEventLog.empty();
     for (const event of events) {
-      log = log.append(event);
+      log = log.append(event, options);
     }
     return log;
   }
 
-  static async parse(stream: AsyncIterable<Uint8Array>): Promise<KeyEventLog> {
+  static async parse(stream: AsyncIterable<Uint8Array>, options?: AppendOptions): Promise<KeyEventLog> {
     let log = KeyEventLog.empty();
 
     for await (const message of parse(stream)) {
       // TODO: Verify that the message is a valid KeyEventBody before casting
       if (message.body.t === "icp" || message.body.t === "ixn" || message.body.t === "rot") {
-        log = log.append(message as Message<KeyEventBody>);
+        log = log.append(message as Message<KeyEventBody>, options);
       }
     }
 
@@ -54,11 +61,14 @@ export class KeyEventLog {
     return this.#events;
   }
 
-  append(message: Message<KeyEventBody>): KeyEventLog {
+  append(message: Message<KeyEventBody>, options?: AppendOptions): KeyEventLog {
     const sigs = message.attachments.ControllerIdxSigs ?? [];
     const wigs = message.attachments.WitnessIdxSigs ?? [];
     const body = message.body;
     const bodyRaw = new Message(body).raw;
+
+    const verifySigning = options?.allowPartiallySigned ? verifySignaturesOrThrow : verifyThresholdOrThrow;
+    const verifyWitness = options?.allowPartiallyWitnessed ? verifySignaturesOrThrow : verifyThresholdOrThrow;
 
     switch (body.t) {
       case "icp": {
@@ -71,14 +81,14 @@ export class KeyEventLog {
           throw new Error("Inception event must have at least one key");
         }
 
-        verifyOrThrow(bodyRaw, {
+        verifySigning(bodyRaw, {
           keys: icp.k,
           threshold: icp.kt as string[] | string,
           sigs,
         });
 
         if (icp.b && Array.isArray(icp.b) && icp.b.length > 0) {
-          verifyOrThrow(bodyRaw, {
+          verifyWitness(bodyRaw, {
             keys: icp.b,
             threshold: icp.bt as string[] | string,
             sigs: wigs,
@@ -93,13 +103,13 @@ export class KeyEventLog {
         }
 
         const state = this.#state;
-        verifyOrThrow(bodyRaw, {
+        verifySigning(bodyRaw, {
           keys: state.signingKeys,
           threshold: state.signingThreshold as string[] | string,
           sigs,
         });
         if (state.backers && state.backers.length > 0) {
-          verifyOrThrow(bodyRaw, {
+          verifyWitness(bodyRaw, {
             keys: state.backers,
             threshold: state.backerThreshold as string[] | string,
             sigs: wigs,

--- a/src/core/key-event.test.ts
+++ b/src/core/key-event.test.ts
@@ -19,21 +19,21 @@ function inceptLog(key: KeyPair, nextKey: KeyPair): KeyEventLog {
 describe("KeyEvent", () => {
   describe("constructor", () => {
     test("body returns the event body", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [] });
       assert.equal(event.body.t, "icp");
       assert.equal(event.body.k[0], key.publicKey);
     });
 
     test("raw returns non-empty Uint8Array", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [] });
       assert.ok(event.raw instanceof Uint8Array);
       assert.ok(event.raw.length > 0);
     });
 
     test("raw bytes encode the body", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [] });
       const text = new TextDecoder().decode(event.raw);
       assert.ok(text.includes(key.publicKey));
@@ -48,8 +48,8 @@ describe("KeyEvent", () => {
     });
 
     test("transferable single-sig AID has correct fields in spec order", () => {
-      const key0 = generateKeyPair("key0");
-      const key1 = generateKeyPair("key1");
+      const key0 = generateKeyPair({ seed: "key0" });
+      const key1 = generateKeyPair({ seed: "key1" });
       const event = incept({
         signingKeys: [key0.publicKey],
         nextKeys: [key1.publicKeyDigest],
@@ -75,7 +75,7 @@ describe("KeyEvent", () => {
     });
 
     test("non-transferable single-sig AID has correct fields in spec order", () => {
-      const ntKey = generateKeyPair("ntKey", { nonTransferable: true });
+      const ntKey = generateKeyPair({ seed: "ntKey", nonTransferable: true });
       const event = incept({ signingKeys: [ntKey.publicKey], nextKeys: [] });
 
       assert.deepStrictEqual(event.body, {
@@ -96,13 +96,13 @@ describe("KeyEvent", () => {
     });
 
     test("toad defaults to 0 with no witnesses", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [] });
       assert.equal(event.body.bt, "0");
     });
 
     test("toad defaults to 1 with one witness", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({
         signingKeys: [key.publicKey],
         nextKeys: [],
@@ -112,7 +112,7 @@ describe("KeyEvent", () => {
     });
 
     test("toad defaults to n-1 with multiple witnesses", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({
         signingKeys: [key.publicKey],
         nextKeys: [],
@@ -126,7 +126,7 @@ describe("KeyEvent", () => {
     });
 
     test("explicit toad overrides default", () => {
-      const key = generateKeyPair("k0");
+      const key = generateKeyPair({ seed: "k0" });
       const event = incept({
         signingKeys: [key.publicKey],
         nextKeys: [],
@@ -137,15 +137,15 @@ describe("KeyEvent", () => {
     });
 
     test("fields are in spec order", () => {
-      const key = generateKeyPair("k0");
-      const next = generateKeyPair("k1");
+      const key = generateKeyPair({ seed: "k0" });
+      const next = generateKeyPair({ seed: "k1" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [next.publicKeyDigest] });
       assert.deepEqual(Object.keys(event.body), ["v", "t", "d", "i", "s", "kt", "k", "nt", "n", "bt", "b", "c", "a"]);
     });
 
     test("d and i are equal for transferable single-sig AID (self-addressing)", () => {
-      const key = generateKeyPair("k0");
-      const next = generateKeyPair("k1");
+      const key = generateKeyPair({ seed: "k0" });
+      const next = generateKeyPair({ seed: "k1" });
       const event = incept({ signingKeys: [key.publicKey], nextKeys: [next.publicKeyDigest] });
       const body = event.body;
       assert.equal(body.d, body.i);
@@ -154,48 +154,48 @@ describe("KeyEvent", () => {
 
   describe("interact", () => {
     test("produces correct field order", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const event = interact(log.state);
       assert.deepEqual(Object.keys(event.body), ["v", "t", "d", "i", "s", "p", "a"]);
     });
 
     test("increments sequence number", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const event = interact(log.state);
       assert.equal(event.body.s, "1");
     });
 
     test("references prior event digest", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const event = interact(log.state);
       assert.equal(event.body.p, log.state.lastEvent.d);
     });
 
     test("identifier matches state", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const event = interact(log.state);
       assert.equal(event.body.i, log.state.identifier);
     });
 
     test("without data produces empty a field", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const event = interact(log.state);
       assert.deepEqual(event.body.a, []);
     });
 
     test("with data wraps it in a field array", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       const log = inceptLog(key0, key1);
       const anchor = { i: "EFoo", s: "0", d: "EBar" };
       const event = interact(log.state, { data: anchor });
@@ -203,8 +203,8 @@ describe("KeyEvent", () => {
     });
 
     test("chained interactions increment sequence correctly", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
       let log = inceptLog(key0, key1);
 
       for (let i = 1; i <= 3; i++) {
@@ -310,7 +310,7 @@ describe("KeyEvent", () => {
     });
 
     test("throws when state has no next key digest", () => {
-      const key0 = generateKeyPair("k0");
+      const key0 = generateKeyPair({ seed: "k0" });
       const event = incept({ signingKeys: [key0.publicKey], nextKeys: [] });
       const sigs = sign(event, [key0]);
       const log = KeyEventLog.empty().append(new Message(event.body, { ControllerIdxSigs: sigs }));
@@ -321,9 +321,9 @@ describe("KeyEvent", () => {
     });
 
     test("increments sequence from lastEvent", () => {
-      const key0 = generateKeyPair("k0");
-      const key1 = generateKeyPair("k1");
-      const key2 = generateKeyPair("k2");
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
+      const key2 = generateKeyPair({ seed: "k2" });
       const log = inceptLog(key0, key1);
       const event = rotate(log.state, {
         signingKeys: [key1.publicKey],

--- a/src/core/keys.test.ts
+++ b/src/core/keys.test.ts
@@ -18,22 +18,22 @@ describe("generateKeyPair", () => {
   });
 
   test("returns a non-transferable public key (B prefix) when nonTransferable is true", () => {
-    const pair = generateKeyPair(undefined, { nonTransferable: true });
+    const pair = generateKeyPair({ nonTransferable: true });
     assert.equal(pair.publicKey[0], "B");
     assert.equal(pair.publicKey.length, 44);
   });
 
   test("returns a deterministic key pair for the same seed", () => {
-    const a = generateKeyPair("test-seed");
-    const b = generateKeyPair("test-seed");
+    const a = generateKeyPair({ seed: "test-seed" });
+    const b = generateKeyPair({ seed: "test-seed" });
     assert.equal(a.publicKey, b.publicKey);
     assert.deepEqual(a.privateKey, b.privateKey);
     assert.equal(a.publicKeyDigest, b.publicKeyDigest);
   });
 
   test("returns different key pairs for different seeds", () => {
-    const a = generateKeyPair("seed-a");
-    const b = generateKeyPair("seed-b");
+    const a = generateKeyPair({ seed: "seed-a" });
+    const b = generateKeyPair({ seed: "seed-b" });
     assert.notEqual(a.publicKey, b.publicKey);
   });
 
@@ -44,14 +44,14 @@ describe("generateKeyPair", () => {
   });
 
   test("publicKeyDigest is a 44-character blake3_256 CESR string (E prefix)", () => {
-    const pair = generateKeyPair("digest-test");
+    const pair = generateKeyPair({ seed: "digest-test" });
     assert.equal(pair.publicKeyDigest[0], "E");
     assert.equal(pair.publicKeyDigest.length, 44);
   });
 
   test("seed and nonTransferable can be combined", () => {
-    const a = generateKeyPair("my-seed", { nonTransferable: true });
-    const b = generateKeyPair("my-seed", { nonTransferable: true });
+    const a = generateKeyPair({ seed: "my-seed", nonTransferable: true });
+    const b = generateKeyPair({ seed: "my-seed", nonTransferable: true });
     assert.equal(a.publicKey[0], "B");
     assert.equal(a.publicKey, b.publicKey);
   });

--- a/src/core/keys.ts
+++ b/src/core/keys.ts
@@ -9,12 +9,13 @@ export interface KeyPair {
 }
 
 export interface GenerateKeyPairOptions {
+  seed?: string;
   nonTransferable?: boolean;
 }
 
-export function generateKeyPair(seed?: string, options?: GenerateKeyPairOptions): KeyPair {
-  const privateKey = seed
-    ? blake3(new TextEncoder().encode(seed), { dkLen: 32 })
+export function generateKeyPair(options?: GenerateKeyPairOptions): KeyPair {
+  const privateKey = options?.seed
+    ? blake3(new TextEncoder().encode(options.seed), { dkLen: 32 })
     : crypto.getRandomValues(new Uint8Array(32));
 
   const rawPublicKey = ed25519.getPublicKey(privateKey);

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -8,7 +8,7 @@ import { receipt } from "./receipt-event.ts";
 import { incept as registry } from "./registry-event.ts";
 import { exchange, query, reply } from "./routed-event.ts";
 import { sign } from "./sign.ts";
-import { verify } from "./verify.ts";
+import { verifyThreshold } from "./verify.ts";
 
 export {
   Attachments,
@@ -92,7 +92,7 @@ export const keri = {
   receipt,
   utils: {
     sign,
-    verify,
+    verifyThreshold,
     formatDate,
     generateKeyPair,
     digest,

--- a/src/core/sign.test.ts
+++ b/src/core/sign.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from "node:test";
 import { Indexer, Matter } from "../cesr/__main__.ts";
 import { generateKeyPair } from "./keys.ts";
 import { sign } from "./sign.ts";
-import { verify } from "./verify.ts";
+import { verifyThreshold } from "./verify.ts";
 
 describe("sign", () => {
   const payload = new TextEncoder().encode("test message");
@@ -13,7 +13,7 @@ describe("sign", () => {
       const { publicKey, privateKey } = generateKeyPair();
       const sig = sign(payload, { key: privateKey });
       const indexedSig = Indexer.convert(Matter.parse(sig), 0).text();
-      const result = verify(payload, { keys: [publicKey], sigs: [indexedSig], threshold: "1" });
+      const result = verifyThreshold(payload, { keys: [publicKey], sigs: [indexedSig], threshold: "1" });
       assert.deepEqual(result.ok, true);
     });
 
@@ -30,7 +30,7 @@ describe("sign", () => {
     test("produces a signature that verifies against the key at the given index", () => {
       const { publicKey, privateKey } = generateKeyPair();
       const sig = sign(payload, { key: privateKey, index: 0 });
-      const result = verify(payload, { keys: [publicKey], sigs: [sig], threshold: "1" });
+      const result = verifyThreshold(payload, { keys: [publicKey], sigs: [sig], threshold: "1" });
       assert.deepEqual(result.ok, true);
     });
 

--- a/src/core/verify.test.ts
+++ b/src/core/verify.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { generateKeyPair, type KeyPair } from "./keys.ts";
 import { sign } from "./sign.ts";
-import { verify, verifyOrThrow } from "./verify.ts";
+import { verifyThreshold, verifyThresholdOrThrow } from "./verify.ts";
 
 function generateKeys(count: number): KeyPair[] {
   const keys: KeyPair[] = [];
@@ -12,13 +12,13 @@ function generateKeys(count: number): KeyPair[] {
   return keys;
 }
 
-describe("verify", () => {
+describe("verifyThreshold", () => {
   const payload = new TextEncoder().encode("test message");
   const keys = generateKeys(3);
 
   test("returns ok for a single valid signature", () => {
     const sigs = [sign(payload, { key: keys[0].privateKey, index: 0 })];
-    assert.deepEqual(verify(payload, { threshold: "1", keys: [keys[0].publicKey], sigs }), { ok: true });
+    assert.deepEqual(verifyThreshold(payload, { threshold: "1", keys: [keys[0].publicKey], sigs }), { ok: true });
   });
 
   test("returns ok when exactly enough signatures meet the threshold", () => {
@@ -26,31 +26,33 @@ describe("verify", () => {
       sign(payload, { key: keys[0].privateKey, index: 0 }),
       sign(payload, { key: keys[2].privateKey, index: 2 }),
     ];
-    assert.deepEqual(verify(payload, { threshold: "2", keys: keys.map((k) => k.publicKey), sigs }), { ok: true });
+    assert.deepEqual(verifyThreshold(payload, { threshold: "2", keys: keys.map((k) => k.publicKey), sigs }), {
+      ok: true,
+    });
   });
 
   test("returns error when no signatures are provided", () => {
     const key = generateKeyPair();
-    const result = verify(payload, { threshold: "1", keys: [key.publicKey], sigs: [] });
+    const result = verifyThreshold(payload, { threshold: "1", keys: [key.publicKey], sigs: [] });
     assert.deepEqual(result, { ok: false, error: "Threshold not met: 0 weight provided, but 1 required" });
   });
 
   test("returns error when too few signatures are provided", () => {
     const sigs = [sign(payload, { key: keys[0].privateKey, index: 0 })];
-    const result = verify(payload, { threshold: "2", keys: [keys[0].publicKey, keys[1].publicKey], sigs });
+    const result = verifyThreshold(payload, { threshold: "2", keys: [keys[0].publicKey, keys[1].publicKey], sigs });
     assert.deepEqual(result, { ok: false, error: "Threshold not met: 1 weight provided, but 2 required" });
   });
 
   test("returns error when signature does not match key", () => {
     const wrongSig = sign(payload, { key: keys[1].privateKey, index: 0 });
-    const result = verify(payload, { threshold: "1", keys: [keys[0].publicKey], sigs: [wrongSig] });
+    const result = verifyThreshold(payload, { threshold: "1", keys: [keys[0].publicKey], sigs: [wrongSig] });
     assert.deepEqual(result, { ok: false, error: "Invalid signature for key at index 0" });
   });
 
   test("returns error when payload has been tampered with", () => {
     const tampered = new TextEncoder().encode("tampered message");
     const sigs = [sign(payload, { key: keys[0].privateKey, index: 0 })];
-    const result = verify(tampered, { threshold: "1", keys: [keys[0].publicKey], sigs });
+    const result = verifyThreshold(tampered, { threshold: "1", keys: [keys[0].publicKey], sigs });
     assert.deepEqual(result, { ok: false, error: "Invalid signature for key at index 0" });
   });
 
@@ -60,29 +62,33 @@ describe("verify", () => {
       sign(payload, { key: keys[1].privateKey, index: 1 }),
     ];
     assert.deepEqual(
-      verify(payload, { threshold: ["1/2", "1/2"], keys: [keys[0].publicKey, keys[1].publicKey], sigs }),
+      verifyThreshold(payload, { threshold: ["1/2", "1/2"], keys: [keys[0].publicKey, keys[1].publicKey], sigs }),
       { ok: true },
     );
   });
 
   test("returns error for fractional threshold when weight is insufficient", () => {
     const sigs = [sign(payload, { key: keys[0].privateKey, index: 0 })];
-    const result = verify(payload, { threshold: ["1/2", "1/2"], keys: [keys[0].publicKey, keys[1].publicKey], sigs });
+    const result = verifyThreshold(payload, {
+      threshold: ["1/2", "1/2"],
+      keys: [keys[0].publicKey, keys[1].publicKey],
+      sigs,
+    });
     assert.equal(result.ok, false);
   });
 });
 
-describe("verifyOrThrow", () => {
+describe("verifyThresholdOrThrow", () => {
   const key = generateKeyPair();
   const payload = new TextEncoder().encode("test message");
 
   test("does not throw for a valid signature", () => {
     const sigs = [sign(payload, { key: key.privateKey, index: 0 })];
-    assert.doesNotThrow(() => verifyOrThrow(payload, { threshold: "1", keys: [key.publicKey], sigs }));
+    assert.doesNotThrow(() => verifyThresholdOrThrow(payload, { threshold: "1", keys: [key.publicKey], sigs }));
   });
 
   test("throws with the error message on failure", () => {
-    assert.throws(() => verifyOrThrow(payload, { threshold: "1", keys: [key.publicKey], sigs: [] }), {
+    assert.throws(() => verifyThresholdOrThrow(payload, { threshold: "1", keys: [key.publicKey], sigs: [] }), {
       message: "Threshold not met: 0 weight provided, but 1 required",
     });
   });

--- a/src/core/verify.ts
+++ b/src/core/verify.ts
@@ -5,7 +5,7 @@ import { parseThreshold, type Threshold } from "./threshold.ts";
 export interface VerifyOptions {
   threshold: Threshold;
   keys: string[];
-  sigs: string[];
+  sigs: string[]; // Indexer-encoded; sig.index identifies which key it signs for
 }
 
 export type VerifyResult =
@@ -18,21 +18,17 @@ export type VerifyResult =
       error: string;
     };
 
-function verifySignature(payload: Uint8Array, key: Matter, sig: Indexer | Matter): boolean {
+export function verifySignature(payload: Uint8Array, key: Matter, sig: Uint8Array): boolean {
   switch (key.code) {
     case Matter.Code.Ed25519:
     case Matter.Code.Ed25519N:
-      // TODO:
-      // We can check the code of the signature,
-      // but it does not really matter since it will be verified correctly regardless.
-      // Anyway, revisit later
-      return ed25519.verify(sig.raw, payload, key.raw);
+      return ed25519.verify(sig, payload, key.raw);
     default:
       throw new Error(`Unsupported key code: ${key.code}`);
   }
 }
 
-export function verify(payload: Uint8Array, options: VerifyOptions): VerifyResult {
+export function verifyThreshold(payload: Uint8Array, options: VerifyOptions): VerifyResult {
   const keys = options.keys.map((key) => Matter.parse(key));
   const sigs = options.sigs.map((sig) => Indexer.parse(sig));
   const threshold = parseThreshold(options.threshold, options.keys.length);
@@ -45,7 +41,7 @@ export function verify(payload: Uint8Array, options: VerifyOptions): VerifyResul
       continue;
     }
 
-    if (!verifySignature(payload, keys[idx], sig)) {
+    if (!verifySignature(payload, keys[idx], sig.raw)) {
       return { ok: false, error: `Invalid signature for key at index ${idx}` };
     }
 
@@ -59,8 +55,34 @@ export function verify(payload: Uint8Array, options: VerifyOptions): VerifyResul
   return { ok: true };
 }
 
-export function verifyOrThrow(payload: Uint8Array, options: VerifyOptions): void {
-  const result = verify(payload, options);
+export function verifyThresholdOrThrow(payload: Uint8Array, options: VerifyOptions): void {
+  const result = verifyThreshold(payload, options);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+}
+
+/**
+ * Validates that every signature present is cryptographically valid for its key,
+ * but does NOT check that the threshold is met.
+ */
+export function verifySignatures(payload: Uint8Array, options: VerifyOptions): VerifyResult {
+  const keys = options.keys.map((key) => Matter.parse(key));
+  const sigs = options.sigs.map((sig) => Indexer.parse(sig));
+
+  for (let idx = 0; idx < keys.length; idx++) {
+    const sig = sigs.find((s) => s.index === idx);
+    if (!sig) continue;
+    if (!verifySignature(payload, keys[idx], sig.raw)) {
+      return { ok: false, error: `Invalid signature for key at index ${idx}` };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function verifySignaturesOrThrow(payload: Uint8Array, options: VerifyOptions): void {
+  const result = verifySignatures(payload, options);
   if (!result.ok) {
     throw new Error(result.error);
   }

--- a/src/core/witness-client.test.ts
+++ b/src/core/witness-client.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert";
+import { test } from "node:test";
+import { Message } from "../cesr/__main__.ts";
+import { incept, type KeyEvent } from "./key-event.ts";
+import { generateKeyPair, type KeyPair } from "./keys.ts";
+import { receipt } from "./receipt-event.ts";
+import { sign } from "./sign.ts";
+import { WitnessClient } from "./witness-client.ts";
+
+function makeEvent() {
+  const sigKey = generateKeyPair();
+  const witnessKey = generateKeyPair(undefined, { nonTransferable: true });
+
+  const event = incept({
+    signingKeys: [sigKey.publicKey],
+    nextKeys: [],
+    wits: [witnessKey.publicKey],
+  });
+
+  event.attachments.ControllerIdxSigs.push(sign(event.raw, { key: sigKey.privateKey, index: 0 }));
+
+  return { event, sigKey, witnessKey };
+}
+
+function makeReceiptResponse(event: KeyEvent, witnessKey: KeyPair) {
+  const rct = receipt({ d: event.body.d, i: event.body.i, s: event.body.s });
+  const witnessSig = sign(event.raw, { key: witnessKey.privateKey });
+  const receiptMsg = new Message(rct.body, {
+    NonTransReceiptCouples: [{ prefix: witnessKey.publicKey, sig: witnessSig }],
+  });
+  return JSON.stringify(receiptMsg.body) + receiptMsg.attachments.text();
+}
+
+test("receipt() returns the receipt when the witness signature is valid", async () => {
+  const { event, witnessKey } = makeEvent();
+  const body = makeReceiptResponse(event, witnessKey);
+
+  const client = new WitnessClient("http://witness.example", async () => new Response(body));
+  const rct = await client.receipt(event);
+
+  assert.strictEqual(rct.body.t, "rct");
+  assert.strictEqual(rct.body.d, event.body.d);
+  assert.strictEqual(rct.attachments.NonTransReceiptCouples[0].prefix, witnessKey.publicKey);
+});
+
+test("receipt() throws when the witness signature is invalid", async () => {
+  const { event, witnessKey } = makeEvent();
+  const attackerKey = generateKeyPair(undefined, { nonTransferable: true });
+
+  const rct = receipt({ d: event.body.d, i: event.body.i, s: event.body.s });
+  const badSig = sign(event.raw, { key: attackerKey.privateKey });
+  const receiptMsg = new Message(rct.body, {
+    NonTransReceiptCouples: [{ prefix: witnessKey.publicKey, sig: badSig }],
+  });
+  const body = JSON.stringify(receiptMsg.body) + receiptMsg.attachments.text();
+
+  const client = new WitnessClient("http://witness.example", async () => new Response(body));
+  await assert.rejects(() => client.receipt(event), /Invalid witness signature from/);
+});
+
+test("receipt() throws when the response is not OK", async () => {
+  const { event } = makeEvent();
+
+  const client = new WitnessClient("http://witness.example", async () => new Response("Bad Request", { status: 400 }));
+  await assert.rejects(() => client.receipt(event), /Failed to submit event to witness/);
+});
+
+test("receipt() throws when no matching receipt is returned", async () => {
+  const { event } = makeEvent();
+
+  const client = new WitnessClient("http://witness.example", async () => new Response(""));
+  await assert.rejects(() => client.receipt(event), /No receipt returned from/);
+});
+
+test("receipt() throws for non-http protocols", async () => {
+  const { event } = makeEvent();
+
+  const client = new WitnessClient("ftp://witness.example", async () => new Response(""));
+  await assert.rejects(() => client.receipt(event), /Invalid protocol/);
+});

--- a/src/core/witness-client.test.ts
+++ b/src/core/witness-client.test.ts
@@ -9,7 +9,7 @@ import { WitnessClient } from "./witness-client.ts";
 
 function makeEvent() {
   const sigKey = generateKeyPair();
-  const witnessKey = generateKeyPair(undefined, { nonTransferable: true });
+  const witnessKey = generateKeyPair({ nonTransferable: true });
 
   const event = incept({
     signingKeys: [sigKey.publicKey],
@@ -45,7 +45,7 @@ test("receipt() returns the receipt when the witness signature is valid", async 
 
 test("receipt() throws when the witness signature is invalid", async () => {
   const { event, witnessKey } = makeEvent();
-  const attackerKey = generateKeyPair(undefined, { nonTransferable: true });
+  const attackerKey = generateKeyPair({ nonTransferable: true });
 
   const rct = receipt({ d: event.body.d, i: event.body.i, s: event.body.s });
   const badSig = sign(event.raw, { key: attackerKey.privateKey });

--- a/src/core/witness-client.ts
+++ b/src/core/witness-client.ts
@@ -1,0 +1,49 @@
+import { Matter, type Message, parse } from "../cesr/__main__.ts";
+import type { KeyEventBody } from "./key-event.ts";
+import type { ReceiptEvent } from "./receipt-event.ts";
+import { verifySignature } from "./verify.ts";
+
+export class WitnessClient {
+  #url: string;
+  #fetch: typeof globalThis.fetch;
+
+  constructor(url: string, fetch?: typeof globalThis.fetch) {
+    this.#url = url;
+    this.#fetch = fetch ?? globalThis.fetch;
+  }
+
+  async receipt(event: Message<KeyEventBody>): Promise<ReceiptEvent> {
+    const url = new URL("/receipts", this.#url);
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Invalid protocol: ${url}`);
+    }
+
+    const fetchResponse = await this.#fetch(url, {
+      method: "POST",
+      body: JSON.stringify(event.body),
+      headers: {
+        "Content-Type": "application/cesr+json",
+        "CESR-ATTACHMENT": event.attachments.text(),
+      },
+    });
+
+    if (!fetchResponse.ok || !fetchResponse.body) {
+      throw new Error(`Failed to submit event to witness: ${fetchResponse.status} ${fetchResponse.statusText}`);
+    }
+
+    for await (const incoming of parse(fetchResponse.body)) {
+      if (incoming.body.t === "rct" && incoming.body.d === event.body.d) {
+        for (const couple of incoming.attachments.NonTransReceiptCouples) {
+          if (!verifySignature(event.raw, Matter.parse(couple.prefix), Matter.parse(couple.sig).raw)) {
+            throw new Error(`Invalid witness signature from ${couple.prefix}`);
+          }
+        }
+
+        return incoming as ReceiptEvent;
+      }
+    }
+
+    throw new Error(`No receipt returned from ${this.#url}`);
+  }
+}

--- a/src/storage/sqlite/storage-sqlite.ts
+++ b/src/storage/sqlite/storage-sqlite.ts
@@ -162,10 +162,11 @@ export class SqliteControllerStorage implements KeyEventStorage, PrivateKeyStora
   }
 
   saveMessage(message: Message): void {
+    // TODO: Should we use a flag to indicate "upsert" or "insert" ?
     const statement = [
       "INSERT INTO event(event_id, protocol, type, sn, event_json, attachments)",
       "VALUES ($event_id, $protocol, $type, $sn, $event_json, $attachments)",
-      "ON CONFLICT(event_id) DO NOTHING",
+      "ON CONFLICT(event_id) DO UPDATE SET attachments = excluded.attachments",
     ].join("\n");
 
     this.#db.execute(statement, prepareRow(message));

--- a/src/witness/witness-router.test.ts
+++ b/src/witness/witness-router.test.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { Attachments, Indexer, Matter } from "../cesr/__main__.ts";
+import { generateKeyPair } from "../core/keys.ts";
 import { type InceptEventBody, type KeyEvent, keri } from "../core/main.ts";
 import { NodeSqliteDatabase, SqliteControllerStorage } from "../storage/sqlite/storage-sqlite.ts";
 import { parseKeyEvents } from "./parser.ts";
@@ -24,7 +25,7 @@ async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
 function makeWitness(): Witness {
   const storage = new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:")));
   return new Witness({
-    privateKey: ed25519.utils.randomSecretKey(crypto.getRandomValues(new Uint8Array(32))),
+    privateKey: generateKeyPair().privateKey,
     url: "http://localhost:5631",
     storage,
   });
@@ -59,11 +60,8 @@ class TestContext {
   }
 }
 
-const privateKey0 = ed25519.utils.randomSecretKey(crypto.getRandomValues(new Uint8Array(32)));
-const privateKey1 = ed25519.utils.randomSecretKey(crypto.getRandomValues(new Uint8Array(32)));
-
-const pubKey0 = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(privateKey0) }).text();
-const pubKey1 = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(privateKey1) }).text();
+const { privateKey: privateKey0, publicKey: pubKey0 } = generateKeyPair();
+const { publicKey: pubKey1 } = generateKeyPair();
 
 const icp = keri.incept({
   signingKeys: [pubKey0],
@@ -115,6 +113,77 @@ describe("Witness oobi request", () => {
     const message = messages.find((m) => m.message.body.r === "/end/role/add");
     assert.strictEqual(message?.message.body.t, "rpy");
     assert.strictEqual(message?.message.body.r, "/end/role/add");
+  });
+});
+
+describe("Witness message request", () => {
+  test("Should return 400 when CESR-ATTACHMENT header is missing", async () => {
+    const context = new TestContext();
+    const response = await context.fetch(
+      request("/", {
+        method: "POST",
+        body: new TextDecoder().decode(icp.raw),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    assert.strictEqual(response.status, 400);
+  });
+
+  test("Should return 200 for a valid rct message", async () => {
+    const context = new TestContext();
+    await context.receipt(icp, sigs);
+
+    const rct = keri.receipt({ d: icp.body.d, i: icp.body.i, s: "0" });
+    const rctAtc = new Attachments({ NonTransReceiptCouples: [] });
+
+    const response = await context.fetch(
+      request("/", {
+        method: "POST",
+        body: new TextDecoder().decode(rct.raw),
+        headers: { "CESR-ATTACHMENT": rctAtc.text() },
+      }),
+    );
+
+    assert.strictEqual(response.status, 200);
+  });
+
+  test("Should merge witness receipt signatures into stored event", async () => {
+    const context1 = new TestContext();
+    const context2 = new TestContext();
+
+    const icpWithWitnesses = keri.incept({
+      signingKeys: [pubKey0],
+      nextKeys: [pubKey1],
+      wits: [context1.witness.aid, context2.witness.aid],
+      toad: 1,
+    });
+    const icpSigs = [Indexer.crypto.ed25519_sig(ed25519.sign(icpWithWitnesses.raw, privateKey0), 0).text()];
+
+    await context1.receipt(icpWithWitnesses, icpSigs);
+    const rctResponse = await context2.receipt(icpWithWitnesses, icpSigs);
+    assert(rctResponse.body);
+    const [rctMessage] = await collect(parseKeyEvents(rctResponse.body));
+
+    const rct = keri.receipt({ d: icpWithWitnesses.body.d, i: icpWithWitnesses.body.i, s: "0" });
+    const rctAtc = new Attachments({
+      NonTransReceiptCouples: rctMessage.message.attachments.NonTransReceiptCouples,
+    });
+
+    const response = await context1.fetch(
+      request("/", {
+        method: "POST",
+        body: new TextDecoder().decode(rct.raw),
+        headers: { "CESR-ATTACHMENT": rctAtc.text() },
+      }),
+    );
+
+    assert.strictEqual(response.status, 200);
+
+    const oobiResponse = await context1.fetch(request(`/oobi/${icpWithWitnesses.body.i}`, { method: "GET" }));
+    assert(oobiResponse.body);
+    const messages = await collect(parseKeyEvents(oobiResponse.body));
+    assert(messages.length > 0);
+    assert.strictEqual(messages[0].message.attachments.WitnessIdxSigs.length, 2);
   });
 });
 

--- a/src/witness/witness-router.ts
+++ b/src/witness/witness-router.ts
@@ -64,6 +64,20 @@ export function createRouter(witness: Witness): (request: Request) => Promise<Re
     return response;
   }
 
+  async function handleMessageRequest(request: Request): Promise<Response> {
+    const atc = request.headers.get("CESR-ATTACHMENT");
+    if (!atc) {
+      return Response.json({ error: "Bad Request" }, { status: 400 });
+    }
+
+    const bodyText = await request.text();
+    for await (const event of parseKeyEvents(bodyText + atc)) {
+      witness.handleMessage(event.message);
+    }
+
+    return new Response(null, { status: 200 });
+  }
+
   return async function handler(request: Request): Promise<Response> {
     const { method } = request;
     const pathname = new URL(request.url).pathname;
@@ -72,6 +86,9 @@ export function createRouter(witness: Witness): (request: Request) => Promise<Re
       switch (method) {
         case "GET":
           return Response.json({ status: "OK" });
+        case "POST": {
+          return handleMessageRequest(request);
+        }
         default:
           return new Response("Method Not Allowed", { status: 405 });
       }

--- a/src/witness/witness.test.ts
+++ b/src/witness/witness.test.ts
@@ -3,23 +3,27 @@ import { DatabaseSync } from "node:sqlite";
 import { test } from "node:test";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { Indexer, Matter, Message } from "../cesr/__main__.ts";
-import { keri } from "../core/main.ts";
+import { KeyEventLog, keri } from "../core/main.ts";
+import { verifySignature } from "../core/verify.ts";
 import { NodeSqliteDatabase, SqliteControllerStorage } from "../storage/sqlite/storage-sqlite.ts";
 import { createSeed } from "./seed.ts";
 import { Witness, WitnessError } from "./witness.ts";
 
-function makeWitness() {
-  const storage = new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:")));
+function makeWitness(seed = "test-witness") {
   return new Witness({
-    privateKey: ed25519.utils.randomSecretKey(createSeed("test-witness", "salt")),
-    storage,
+    privateKey: ed25519.utils.randomSecretKey(createSeed(seed, "salt")),
+    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
   });
 }
 
-function createInceptEvent() {
+interface InceptOptions {
+  wits?: string[];
+}
+
+function createInceptEvent(options: InceptOptions = {}) {
   const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
   const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
-  const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [] });
+  const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [], wits: options.wits });
   const sig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, controllerKey), 0).text();
   return new Message(icp.body, { ControllerIdxSigs: [sig] });
 }
@@ -40,6 +44,10 @@ test("receipt() endorses a valid event and returns a receipt", () => {
   assert.strictEqual(receipt.body.t, "rct");
   assert.strictEqual(receipt.body.i, msg.body.i);
   assert.strictEqual(receipt.attachments.NonTransReceiptCouples[0].prefix, witness.aid);
+
+  const wig = receipt.attachments.NonTransReceiptCouples[0].sig;
+
+  assert(verifySignature(msg.raw, Matter.parse(witness.aid), Matter.parse(wig).raw));
 });
 
 test("receipt() throws WitnessError when no controller signatures are present", () => {
@@ -65,4 +73,94 @@ test("getKeyEvents() returns empty for unknown AID", () => {
   const witness = makeWitness();
   const stored = Array.from(witness.getKeyEvents("unknown-aid"));
   assert.strictEqual(stored.length, 0);
+});
+
+test("receipt() throws WitnessError when icp controller signature is invalid", () => {
+  const witness = makeWitness();
+  const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
+  const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
+  const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [] });
+
+  // Sign with a different (wrong) key
+  const wrongKey = ed25519.utils.randomSecretKey(createSeed("wrong-key", "salt"));
+  const badSig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, wrongKey), 0).text();
+  const msg = new Message(icp.body, { ControllerIdxSigs: [badSig] });
+
+  assert.throws(() => witness.receipt(msg), WitnessError);
+});
+
+test("receipt() throws WitnessError when ixn controller signature is invalid", () => {
+  const witness = makeWitness();
+  const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
+  const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
+  const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [] });
+  const icpSig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, controllerKey), 0).text();
+  witness.receipt(new Message(icp.body, { ControllerIdxSigs: [icpSig] }));
+
+  const state = KeyEventLog.from(witness.getKeyEvents(icp.body.i)).state;
+  const ixn = keri.interact(state);
+
+  // Sign with a different (wrong) key
+  const wrongKey = ed25519.utils.randomSecretKey(createSeed("wrong-key", "salt"));
+  const badSig = Indexer.crypto.ed25519_sig(ed25519.sign(ixn.raw, wrongKey), 0).text();
+  const msg = new Message(ixn.body, { ControllerIdxSigs: [badSig] });
+
+  assert.throws(() => witness.receipt(msg), WitnessError);
+});
+
+test("handleMessage() is a no-op for non-rct events", () => {
+  const witness = makeWitness();
+  const icp = createInceptEvent();
+
+  witness.handleMessage(icp);
+
+  const stored = Array.from(witness.getKeyEvents(icp.body.i));
+  assert.strictEqual(stored.length, 0);
+});
+
+test("handleMessage() is a no-op when this witness is not a backer", () => {
+  const witness = makeWitness();
+  const otherKey = ed25519.utils.randomSecretKey(createSeed("other-witness", "salt"));
+  const otherPub = new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(otherKey) }).text();
+
+  const icp = createInceptEvent({ wits: [otherPub] });
+  witness.receipt(icp);
+
+  const otherSig = new Matter({ code: Matter.Code.Ed25519_Sig, raw: ed25519.sign(icp.raw, otherKey) }).text();
+  const rct = keri.receipt({ d: icp.body.d, i: icp.body.i, s: icp.body.s });
+  const rctMsg = new Message(rct.body, {
+    NonTransReceiptCouples: [{ prefix: otherPub, sig: otherSig }],
+  });
+
+  witness.handleMessage(rctMsg);
+
+  // event stored but WitnessIdxSigs should be empty (witness is not a backer)
+  const stored = Array.from(witness.getKeyEvents(icp.body.i));
+  assert.strictEqual(stored[0]?.attachments.WitnessIdxSigs.length, 0);
+});
+
+test("handleMessage() merges NonTransReceiptCouples from another witness", () => {
+  const witness = makeWitness();
+  const otherKey = ed25519.utils.randomSecretKey(createSeed("other-witness", "salt"));
+  const otherPub = new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(otherKey) }).text();
+
+  // icp lists both witnesses as backers
+  const icp = createInceptEvent({ wits: [witness.aid, otherPub] });
+  witness.receipt(icp);
+
+  // After receipt() this witness has signed, but only its own WitnessIdxSig is stored
+  const before = Array.from(witness.getKeyEvents(icp.body.i));
+  assert.strictEqual(before[0]?.attachments.WitnessIdxSigs.length, 1);
+
+  // Simulate the other witness sending a receipt with its signature
+  const otherSig = new Matter({ code: Matter.Code.Ed25519_Sig, raw: ed25519.sign(icp.raw, otherKey) }).text();
+  const rct = keri.receipt({ d: icp.body.d, i: icp.body.i, s: icp.body.s });
+  const rctMsg = new Message(rct.body, {
+    NonTransReceiptCouples: [{ prefix: otherPub, sig: otherSig }],
+  });
+
+  witness.handleMessage(rctMsg);
+
+  const after = Array.from(witness.getKeyEvents(icp.body.i));
+  assert.strictEqual(after[0]?.attachments.WitnessIdxSigs.length, 2);
 });

--- a/src/witness/witness.test.ts
+++ b/src/witness/witness.test.ts
@@ -3,15 +3,15 @@ import { DatabaseSync } from "node:sqlite";
 import { test } from "node:test";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { Indexer, Matter, Message } from "../cesr/__main__.ts";
+import { generateKeyPair } from "../core/keys.ts";
 import { KeyEventLog, keri } from "../core/main.ts";
 import { verifySignature } from "../core/verify.ts";
 import { NodeSqliteDatabase, SqliteControllerStorage } from "../storage/sqlite/storage-sqlite.ts";
-import { createSeed } from "./seed.ts";
 import { Witness, WitnessError } from "./witness.ts";
 
 function makeWitness(seed = "test-witness") {
   return new Witness({
-    privateKey: ed25519.utils.randomSecretKey(createSeed(seed, "salt")),
+    privateKey: generateKeyPair({ seed }).privateKey,
     storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
   });
 }
@@ -21,8 +21,7 @@ interface InceptOptions {
 }
 
 function createInceptEvent(options: InceptOptions = {}) {
-  const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
-  const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
+  const { privateKey: controllerKey, publicKey: controllerPub } = generateKeyPair();
   const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [], wits: options.wits });
   const sig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, controllerKey), 0).text();
   return new Message(icp.body, { ControllerIdxSigs: [sig] });
@@ -77,12 +76,10 @@ test("getKeyEvents() returns empty for unknown AID", () => {
 
 test("receipt() throws WitnessError when icp controller signature is invalid", () => {
   const witness = makeWitness();
-  const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
-  const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
+  const { publicKey: controllerPub } = generateKeyPair();
   const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [] });
 
-  // Sign with a different (wrong) key
-  const wrongKey = ed25519.utils.randomSecretKey(createSeed("wrong-key", "salt"));
+  const wrongKey = generateKeyPair().privateKey;
   const badSig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, wrongKey), 0).text();
   const msg = new Message(icp.body, { ControllerIdxSigs: [badSig] });
 
@@ -91,8 +88,7 @@ test("receipt() throws WitnessError when icp controller signature is invalid", (
 
 test("receipt() throws WitnessError when ixn controller signature is invalid", () => {
   const witness = makeWitness();
-  const controllerKey = ed25519.utils.randomSecretKey(createSeed("controller", "salt"));
-  const controllerPub = new Matter({ code: Matter.Code.Ed25519, raw: ed25519.getPublicKey(controllerKey) }).text();
+  const { privateKey: controllerKey, publicKey: controllerPub } = generateKeyPair();
   const icp = keri.incept({ signingKeys: [controllerPub], nextKeys: [] });
   const icpSig = Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, controllerKey), 0).text();
   witness.receipt(new Message(icp.body, { ControllerIdxSigs: [icpSig] }));
@@ -100,8 +96,7 @@ test("receipt() throws WitnessError when ixn controller signature is invalid", (
   const state = KeyEventLog.from(witness.getKeyEvents(icp.body.i)).state;
   const ixn = keri.interact(state);
 
-  // Sign with a different (wrong) key
-  const wrongKey = ed25519.utils.randomSecretKey(createSeed("wrong-key", "salt"));
+  const wrongKey = generateKeyPair().privateKey;
   const badSig = Indexer.crypto.ed25519_sig(ed25519.sign(ixn.raw, wrongKey), 0).text();
   const msg = new Message(ixn.body, { ControllerIdxSigs: [badSig] });
 
@@ -120,8 +115,10 @@ test("handleMessage() is a no-op for non-rct events", () => {
 
 test("handleMessage() is a no-op when this witness is not a backer", () => {
   const witness = makeWitness();
-  const otherKey = ed25519.utils.randomSecretKey(createSeed("other-witness", "salt"));
-  const otherPub = new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(otherKey) }).text();
+  const { privateKey: otherKey, publicKey: otherPub } = generateKeyPair({
+    seed: "other-witness",
+    nonTransferable: true,
+  });
 
   const icp = createInceptEvent({ wits: [otherPub] });
   witness.receipt(icp);
@@ -134,25 +131,23 @@ test("handleMessage() is a no-op when this witness is not a backer", () => {
 
   witness.handleMessage(rctMsg);
 
-  // event stored but WitnessIdxSigs should be empty (witness is not a backer)
   const stored = Array.from(witness.getKeyEvents(icp.body.i));
   assert.strictEqual(stored[0]?.attachments.WitnessIdxSigs.length, 0);
 });
 
 test("handleMessage() merges NonTransReceiptCouples from another witness", () => {
   const witness = makeWitness();
-  const otherKey = ed25519.utils.randomSecretKey(createSeed("other-witness", "salt"));
-  const otherPub = new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(otherKey) }).text();
+  const { privateKey: otherKey, publicKey: otherPub } = generateKeyPair({
+    seed: "other-witness",
+    nonTransferable: true,
+  });
 
-  // icp lists both witnesses as backers
   const icp = createInceptEvent({ wits: [witness.aid, otherPub] });
   witness.receipt(icp);
 
-  // After receipt() this witness has signed, but only its own WitnessIdxSig is stored
   const before = Array.from(witness.getKeyEvents(icp.body.i));
   assert.strictEqual(before[0]?.attachments.WitnessIdxSigs.length, 1);
 
-  // Simulate the other witness sending a receipt with its signature
   const otherSig = new Matter({ code: Matter.Code.Ed25519_Sig, raw: ed25519.sign(icp.raw, otherKey) }).text();
   const rct = keri.receipt({ d: icp.body.d, i: icp.body.i, s: icp.body.s });
   const rctMsg = new Message(rct.body, {

--- a/src/witness/witness.ts
+++ b/src/witness/witness.ts
@@ -1,5 +1,5 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
-import { Indexer, Matter, Message } from "../cesr/__main__.ts";
+import { Attachments, Indexer, Matter, Message } from "../cesr/__main__.ts";
 import { type KeyEvent, type KeyEventBody, KeyEventLog, keri, type ReceiptEventBody } from "../core/main.ts";
 import type { KeyEventStorage } from "../storage/key-event-storage.ts";
 
@@ -27,8 +27,7 @@ export class Witness {
     return this.#kel.state.identifier;
   }
 
-  static createKEL(options: WitnessOptions): KeyEventLog {
-    const privateKey = options.privateKey ?? ed25519.utils.randomSecretKey();
+  static createKEL(privateKey: Uint8Array): KeyEventLog {
     const publicKey = new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(privateKey) }).text();
 
     const icp = keri.incept({
@@ -45,7 +44,7 @@ export class Witness {
   constructor(options: WitnessOptions) {
     this.#storage = options.storage;
     this.#privateKey = options.privateKey ?? ed25519.utils.randomSecretKey();
-    this.#kel = Witness.createKEL(options);
+    this.#kel = Witness.createKEL(this.#privateKey);
 
     const events: WitnessEvent[] = [{ message: this.#kel.events[0], timestamp: new Date() }];
 
@@ -97,23 +96,84 @@ export class Witness {
       throw new WitnessError("Missing controller signatures");
     }
 
+    let kel = KeyEventLog.from(this.#storage.getKeyEvents(body.i));
+
+    try {
+      kel = kel.append(message, { allowPartiallyWitnessed: true });
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new WitnessError(`Failed to append message to KEL: ${error.message}`);
+      }
+    }
+
+    const sig = this.#sign(message);
+    const witnessIndex = kel.state.backers.indexOf(this.aid);
+
     const receipt = keri.receipt({ d: message.body.d, i: message.body.i, s: message.body.s });
     receipt.attachments = {
-      NonTransReceiptCouples: [{ prefix: this.#kel.state.identifier, sig: this.#sign(message) }],
+      NonTransReceiptCouples: [{ prefix: this.#kel.state.identifier, sig }],
     };
+
+    const WitnessIdxSigs = witnessIndex >= 0 ? [Indexer.convert(Matter.parse(sig), witnessIndex).text()] : [];
 
     const storedMessage = new Message(message.body, {
       ControllerIdxSigs: message.attachments.ControllerIdxSigs,
-      NonTransReceiptCouples: [
-        ...message.attachments.NonTransReceiptCouples,
-        ...receipt.attachments.NonTransReceiptCouples,
-      ],
+      WitnessIdxSigs,
       FirstSeenReplayCouples: [{ fnu: body.s, dt: new Date() }],
     });
 
     this.#storage.saveMessage(storedMessage);
 
     return receipt;
+  }
+
+  handleMessage(message: Message): void {
+    const body = message.body as KeyEventBody;
+
+    if (body.t !== "rct") {
+      return;
+    }
+
+    if (typeof body.i !== "string" || typeof body.d !== "string") {
+      return;
+    }
+
+    const kel = KeyEventLog.from(this.#storage.getKeyEvents(body.i), {
+      // TODO: This should only be for the event that is this receit
+      allowPartiallyWitnessed: true,
+    });
+
+    if (!kel.state.backers.includes(this.aid)) {
+      return;
+    }
+
+    const storedEvent = kel.events.find((event) => event.body.d === body.d);
+    if (!storedEvent) {
+      return;
+    }
+
+    const existingWigsByIndex = new Map<number, string>();
+    for (const sig of storedEvent.attachments.WitnessIdxSigs) {
+      const indexer = Indexer.parse(sig);
+      existingWigsByIndex.set(indexer.index, sig);
+    }
+
+    for (const couple of message.attachments.NonTransReceiptCouples) {
+      const witnessIndex = kel.state.backers.indexOf(couple.prefix);
+      if (witnessIndex === -1) {
+        continue;
+      }
+      const wigSig = Indexer.convert(Matter.parse(couple.sig), witnessIndex).text();
+      existingWigsByIndex.set(witnessIndex, wigSig);
+    }
+
+    const mergedAttachments = new Attachments({
+      ControllerIdxSigs: storedEvent.attachments.ControllerIdxSigs,
+      WitnessIdxSigs: Array.from(existingWigsByIndex.values()),
+      FirstSeenReplayCouples: storedEvent.attachments.FirstSeenReplayCouples,
+    });
+
+    this.#storage.saveMessage(new Message(storedEvent.body, mergedAttachments));
   }
 
   *getKeyEvents(aid: string): Generator<KeyEvent> {

--- a/test_interop/test_witness_kerijs.ts
+++ b/test_interop/test_witness_kerijs.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert";
+import test, { after, before } from "node:test";
+import { parse } from "../src/cesr/parse.ts";
+import { collectAsync, createController, startKerijsWitness, type Witness } from "./utils.ts";
+
+let wan: Witness;
+let wil: Witness;
+
+const abortController = new AbortController();
+
+before(async () => {
+  wan = await startKerijsWitness({ signal: abortController.signal });
+  wil = await startKerijsWitness({ signal: abortController.signal });
+});
+
+after(() => {
+  abortController.abort();
+});
+
+test("Create identifier with single witness", async () => {
+  const controller = createController();
+  await controller.introduce(wan.oobi);
+  const state = await controller.incept({
+    wits: [wan.aid],
+    toad: 1,
+  });
+
+  const events = await controller.export(state.id);
+  assert.equal(events.length, 1);
+  assert.partialDeepStrictEqual(events[0]?.body, {
+    i: state.id,
+    b: [wan.aid],
+  });
+
+  const response = await fetch(`${wan.url}/oobi/${state.id}`);
+  assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0]?.body.i, state.id);
+  assert.equal(parsed[0].attachments.ControllerIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.WitnessIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.NonTransReceiptCouples.length, 0);
+});
+
+test("Create identifier with two witnesses", async () => {
+  const controller = createController();
+  await controller.introduce(wan.oobi);
+  await controller.introduce(wil.oobi);
+
+  const state = await controller.incept({
+    wits: [wan.aid, wil.aid],
+    toad: 2,
+  });
+
+  const events = await controller.export(state.id);
+  assert.equal(events.length, 1);
+  assert.partialDeepStrictEqual(events[0]?.body, {
+    i: state.id,
+    b: [wan.aid, wil.aid],
+  });
+
+  const response = await fetch(`${wan.url}/oobi/${state.id}`);
+  assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0]?.body.i, state.id);
+  assert.equal(parsed[0].attachments.ControllerIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.WitnessIdxSigs.length, 2);
+  assert.equal(parsed[0].attachments.NonTransReceiptCouples.length, 0);
+});

--- a/test_interop/test_witness_keripy_controller.ts
+++ b/test_interop/test_witness_keripy_controller.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert";
+import test, { after, before } from "node:test";
+import { parse } from "../src/cesr/parse.ts";
+import { KERIPy } from "./keripy.ts";
+import { collectAsync, startKerijsWitness, type Witness } from "./utils.ts";
+
+let wan: Witness;
+let wil: Witness;
+const abortController = new AbortController();
+
+before(async () => {
+  [wan, wil] = await Promise.all([
+    startKerijsWitness({ signal: abortController.signal }),
+    startKerijsWitness({ signal: abortController.signal }),
+  ]);
+});
+
+after(() => {
+  abortController.abort();
+});
+
+test("KERIpy creates identifier with single KERIjs witness", async () => {
+  const keripy = new KERIPy();
+  await keripy.init();
+  await keripy.oobi.resolve(wan.oobi, "wan");
+  await keripy.incept({ wits: [wan.aid], toad: 1, receiptEndpoint: true });
+
+  const aid = await keripy.aid();
+
+  const response = await fetch(`${wan.url}/oobi/${aid}`);
+  assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0]?.body.i, aid);
+  assert.equal(parsed[0].attachments.ControllerIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.WitnessIdxSigs.length, 1);
+});
+
+test("KERIpy creates identifier with two KERIjs witnesses", async () => {
+  const keripy = new KERIPy();
+  await keripy.init();
+  await keripy.oobi.resolve(wan.oobi, "wan");
+  await keripy.oobi.resolve(wil.oobi, "wil");
+  await keripy.incept({ wits: [wan.aid, wil.aid], toad: 2, receiptEndpoint: true });
+
+  const aid = await keripy.aid();
+
+  const [response1, response2] = await Promise.all([fetch(`${wan.url}/oobi/${aid}`), fetch(`${wil.url}/oobi/${aid}`)]);
+
+  assert.equal(response1.status, 200);
+  assert.equal(response2.status, 200);
+});

--- a/test_interop/test_witness_receipt.ts
+++ b/test_interop/test_witness_receipt.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert";
 import test, { after, before } from "node:test";
+import { parse } from "../src/cesr/__main__.ts";
 import { keri, sign, submitToWitnesses } from "../src/main.ts";
-import { createController, startKeripyWitness, type Witness } from "./utils.ts";
+import { collectAsync, createController, startKeripyWitness, type Witness } from "./utils.ts";
 
 let wan: Witness;
 let wil: Witness;
@@ -37,6 +38,14 @@ test("Create identifier with single witness", async () => {
 
   const response = await fetch(`${wan.url}/oobi/${state.id}`);
   assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0]?.body.i, state.id);
+  assert.equal(parsed[0].attachments.ControllerIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.WitnessIdxSigs.length, 1);
+  assert.equal(parsed[0].attachments.NonTransReceiptCouples.length, 0);
 });
 
 test("Create identifier with two witnesses", async () => {

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -44,8 +44,7 @@ export async function startKerijsWitness(opts: { port?: number; signal?: AbortSi
 
   const witness = new WitnessNode({
     storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
-    // SIC! Keripy requires the trailing slash to be able to contruct the path
-    url: `http://localhost:${port}/`,
+    url: `http://localhost:${port}`,
   });
 
   const router = createRouter(witness);
@@ -118,4 +117,12 @@ export async function startKeripyWitness(
   }
 
   return { aid, url, oobi: oobiUrl };
+}
+
+export async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

This PR implements witness signature handling — the witness now validates controller signatures before issuing receipts, stores witness signatures as `WitnessIdxSigs` (indexed) rather than `NonTransReceiptCouples`, and merges signatures from peer witnesses to build fully-witnessed events.

### Changes

**Signature verification split (`src/core/verify.ts`)**
- Renamed `verify`/`verifyOrThrow` → `verifyThreshold`/`verifyThresholdOrThrow` (checks both validity _and_ threshold)
- Added `verifySignatures`/`verifySignaturesOrThrow` — validates each signature cryptographically but does _not_ require the threshold to be met
- Exported `verifySignature` (single key/sig pair) for use in the witness client

**`KeyEventLog` partial-append options (`src/core/key-event-log.ts`)**
- Added `AppendOptions` with `allowPartiallySigned` and `allowPartiallyWitnessed` flags
- Allows a witness to store an incoming event before all witness receipts have been collected, while still rejecting any signatures that are individually invalid

**Witness receipt correctness (`src/witness/witness.ts`)**
- Witness now validates controller signatures before issuing a receipt; returns `WitnessError` on invalid/missing sigs
- Stored events now carry `WitnessIdxSigs` (indexed by backer position) instead of `NonTransReceiptCouples`
- Added `handleMessage()` — merges `NonTransReceiptCouples` from incoming receipt messages into the stored `WitnessIdxSigs`, enabling multi-witness threshold completion

**New POST `/messages` endpoint (`src/witness/witness-router.ts`)**
- Accepts CESR-encoded messages so peer witnesses (or controllers) can push receipts to be merged

**`WitnessClient` (`src/core/witness-client.ts`)**
- Thin HTTP client for submitting a key event to a witness and verifying the returned receipt signature

**Interop tests (`test_interop/`)**
- `test_witness_kerijs.ts` — single- and two-witness identifier creation using keri-js witnesses only
- `test_witness_keripy_controller.ts` — keripy controller against keri-js witnesses

### What's not done yet

- `handleMessage` uses `allowPartiallyWitnessed: true` globally on the whole KEL when it only needs to apply to the specific event being updated
- No threshold check after merging witness signatures (i.e. the witness doesn't yet know when an event is "fully witnessed")
- Rotation events are not tested with witnesses
