### PR TITLE
rename custom condition from "source" to "keri-source"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,8 +92,8 @@ jobs:
         run: deno install --frozen
  
       - name: Deno typecheck
-        run: deno check --conditions=source src
+        run: deno check --conditions=keri-source src
 
       - name: Run test in deno
-        run: deno test --allow-net --allow-read --conditions=source
+        run: deno test --allow-net --allow-read --conditions=keri-source
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
-    "test": "node --test --conditions source --no-warnings 'src/**/*.test.ts'",
-    "test:interop": "node --test --conditions source --test-concurrency=1 --no-warnings 'test_interop/test_*.ts'",
-    "test:vector": "node --test --conditions source --no-warnings 'test_vectors/**/*.test.ts'",
+    "test": "node --test --conditions keri-source --no-warnings 'src/**/*.test.ts'",
+    "test:interop": "node --test --conditions keri-source --test-concurrency=1 --no-warnings 'test_interop/test_*.ts'",
+    "test:vector": "node --test --conditions keri-source --no-warnings 'test_vectors/**/*.test.ts'",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "check": "tsc --noEmit",
@@ -21,35 +21,35 @@
   },
   "imports": {
     "#keri": {
-      "source": "./src/main.ts",
+      "keri-source": "./src/main.ts",
       "default": "./dist/main.js"
     },
     "#keri/encoding": {
-      "source": "./src/encoding/main.ts",
+      "keri-source": "./src/encoding/main.ts",
       "default": "./dist/encoding/main.js"
     },
     "#keri/cesr": {
-      "source": "./src/cesr/__main__.ts",
+      "keri-source": "./src/cesr/__main__.ts",
       "default": "./dist/cesr/__main__.js"
     },
     "#keri/core": {
-      "source": "./src/core/main.ts",
+      "keri-source": "./src/core/main.ts",
       "default": "./dist/core/main.js"
     },
     "#keri/storage": {
-      "source": "./src/storage/main.ts",
+      "keri-source": "./src/storage/main.ts",
       "default": "./dist/storage/main.js"
     },
     "#keri/storage/sqlite": {
-      "source": "./src/storage/sqlite/storage-sqlite.ts",
+      "keri-source": "./src/storage/sqlite/storage-sqlite.ts",
       "default": "./dist/storage/sqlite/storage-sqlite.js"
     },
     "#keri/witness": {
-      "source": "./src/witness/main.ts",
+      "keri-source": "./src/witness/main.ts",
       "default": "./dist/witness/main.js"
     },
     "#keri/nodejs-utils": {
-      "source": "./src/nodejs-utils/serve.ts",
+      "keri-source": "./src/nodejs-utils/serve.ts",
       "default": "./dist/nodejs-utils/serve.js"
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "types": ["node"],
-    "customConditions": ["source"]
+    "customConditions": ["keri-source"]
   }
 }


### PR DESCRIPTION
## Summary
- The `source` condition is a [community-reserved name](https://nodejs.org/api/packages.html#community-conditions-definitions) used by bundlers and dev tools.
- A downstream consumer running with `--conditions=source` (or using a tool that sets it) would have Node resolve our internal `#keri/*` subpath imports to `./src/*.ts` paths — files we don't ship in the published tarball — and crash.
- Rename to `keri-source` so the condition is unique to this package and can't be triggered accidentally from outside.

Touches:
- `package.json`: `imports.*.source` → `keri-source`, and `--conditions source` → `--conditions keri-source` in the three test scripts.
- `tsconfig.json`: `customConditions: ["source"]` → `["keri-source"]`.
- `.github/workflows/ci.yaml`: `--conditions=source` → `--conditions=keri-source` in the two Deno steps.

## Test plan
- [x] `npm run check` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 411 / 411 pass
- [ ] CI passes (Node 22/24/25 matrix + Deno job)