### PR TITLE
feat: mailbox (PoC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ api-docs/
 .pack/
 .vscode/
 .env
+.claude

--- a/package.json
+++ b/package.json
@@ -48,16 +48,20 @@
       "keri-source": "./src/witness/main.ts",
       "default": "./dist/witness/main.js"
     },
+    "#keri/mailbox": {
+      "keri-source": "./src/mailbox/main.ts",
+      "default": "./dist/mailbox/main.js"
+    },
     "#keri/nodejs-utils": {
-      "keri-source": "./src/nodejs-utils/serve.ts",
-      "default": "./dist/nodejs-utils/serve.js"
+      "keri-source": "./src/nodejs-utils/main.ts",
+      "default": "./dist/nodejs-utils/main.js"
     }
   },
   "exports": {
     ".": "./dist/main.js",
     "./sqlite-storage": "./dist/storage/sqlite/storage-sqlite.js",
     "./witness": "./dist/witness/main.js",
-    "./nodejs-utils": "./dist/nodejs-utils/serve.js"
+    "./nodejs-utils": "./dist/nodejs-utils/main.js"
   },
   "files": [
     "dist"

--- a/scripts/serve-mailbox.ts
+++ b/scripts/serve-mailbox.ts
@@ -1,0 +1,47 @@
+import { createServer } from "node:http";
+import { DatabaseSync } from "node:sqlite";
+import { styleText } from "node:util";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { scrypt } from "@noble/hashes/scrypt.js";
+import { createMailboxRouter, Mailbox } from "../src/mailbox/main.ts";
+import { createListener } from "../src/nodejs-utils/serve.ts";
+import { NodeSqliteDatabase, SqliteControllerStorage } from "../src/storage/sqlite/storage-sqlite.ts";
+
+const storage = new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:")));
+
+const port = parseInt(process.env.PORT ?? "3000", 10);
+const passphrase = process.env.PASSPHRASE ?? "password";
+const salt = process.env.SALT ?? "salt";
+const url = process.env.MAILBOX_URL ?? `http://localhost:${port}`;
+
+const seed = scrypt(passphrase, salt, { N: 16384, r: 8, p: 1, dkLen: 32 });
+const privateKey = ed25519.utils.randomSecretKey(seed);
+const mailbox = new Mailbox({ privateKey, url, storage, logger: console });
+
+const router = createMailboxRouter(mailbox, { logger: console });
+const server = createServer(createListener(router, { logger: console }));
+
+server.listen(port, () => {
+  console.log(
+    [
+      "",
+      styleText("green", "Mailbox running at:"),
+      styleText("cyan", `  http://localhost:${port}`),
+      styleText("cyan", `  http://localhost:${port}/oobi`),
+      "",
+      styleText("yellow", "Press Ctrl+C to stop"),
+      "",
+    ].join("\n"),
+  );
+});
+
+function shutdown() {
+  console.log("\nShutting down mailbox...");
+  server.close(() => {
+    console.log("Mailbox stopped.");
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/scripts/serve-witness.ts
+++ b/scripts/serve-witness.ts
@@ -16,11 +16,10 @@ const url = process.env.WITNESS_URL ?? `http://localhost:${port}`;
 
 const seed = scrypt(passphrase, salt, { N: 16384, r: 8, p: 1, dkLen: 32 });
 const privateKey = ed25519.utils.randomSecretKey(seed);
-const witness = new Witness({ privateKey, url, storage });
+const witness = new Witness({ privateKey, url, storage, logger: console });
 
-const router = createRouter(witness);
-const listener = createListener(router, (message, context) => console.log(message, context));
-const server = createServer(listener);
+const router = createRouter(witness, { logger: console });
+const server = createServer(createListener(router, { logger: console }));
 
 server.listen(port, () => {
   console.log(

--- a/src/core/mailbox-client.test.ts
+++ b/src/core/mailbox-client.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import { encodeText, type Message } from "#keri/cesr";
+import { incept } from "./key-event.ts";
+import { generateKeyPair } from "./keys.ts";
+import { MailboxClient } from "./mailbox-client.ts";
+
+function makeMessage(): Message {
+  const { publicKey } = generateKeyPair();
+  return incept({ signingKeys: [publicKey], nextKeys: [] });
+}
+
+function encodeMessage(message: Message): string {
+  return new TextDecoder().decode(message.raw) + encodeText(message.attachments.frames());
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+}
+
+function sseFrame(message: Message, opts: { id?: number; event?: string } = {}): string {
+  const lines: string[] = [];
+  if (opts.id !== undefined) {
+    lines.push(`id: ${opts.id}`);
+  }
+  if (opts.event !== undefined) {
+    lines.push(`event: ${opts.event}`);
+  }
+  lines.push("retry: 5000");
+  lines.push(`data: ${encodeMessage(message)}`);
+  return `${lines.join("\n")}\n\n`;
+}
+
+function eventStreamResponse(body: ReadableStream<Uint8Array>): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe(basename(import.meta.url), () => {
+  describe("sendMessage()", () => {
+    test("should POST to / with correct headers and body", async () => {
+      const message = makeMessage();
+      let captured: Request | undefined;
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async (input, init) => {
+          captured = new Request(input, init);
+          return new Response(null, { status: 204 });
+        },
+      });
+
+      await client.sendMessage(message);
+
+      assert.ok(captured);
+      assert.strictEqual(captured.method, "POST");
+      assert.strictEqual(new URL(captured.url).pathname, "/");
+      assert.strictEqual(captured.headers.get("Content-Type"), "application/cesr+json");
+      assert.strictEqual(captured.headers.get("CESR-DESTINATION"), "EAID");
+      assert.ok(captured.headers.get("CESR-ATTACHMENT") !== null);
+      assert.strictEqual(await captured.text(), JSON.stringify(message.body));
+    });
+
+    test("should forward AbortSignal to fetch", async () => {
+      const controller = new AbortController();
+      let capturedSignal: AbortSignal | null | undefined;
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async (_, init) => {
+          capturedSignal = init?.signal;
+          return new Response(null, { status: 204 });
+        },
+      });
+
+      await client.sendMessage(makeMessage(), controller.signal);
+      assert.strictEqual(capturedSignal, controller.signal);
+    });
+
+    test("should throw when response is not ok", async () => {
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => new Response("nope", { status: 500, statusText: "Server Error" }),
+      });
+      await assert.rejects(client.sendMessage(makeMessage()), /500/);
+    });
+
+    test("should return [] for 204 No Content", async () => {
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => new Response(null, { status: 204 }),
+      });
+      assert.deepStrictEqual(await client.sendMessage(makeMessage()), []);
+    });
+
+    test("should return [] for application/json response", async () => {
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => Response.json({ ok: true }),
+      });
+      assert.deepStrictEqual(await client.sendMessage(makeMessage()), []);
+    });
+
+    test("should parse single SSE message", async () => {
+      const reply = makeMessage();
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks([sseFrame(reply, { id: 1, event: "/credential" })])),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.t, "icp");
+      assert.strictEqual(messages[0].body.i, reply.body.i);
+    });
+
+    test("should parse multiple SSE messages in one chunk", async () => {
+      const a = makeMessage();
+      const b = makeMessage();
+      const body = sseFrame(a, { id: 1 }) + sseFrame(b, { id: 2 });
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks([body])),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 2);
+      assert.strictEqual(messages[0].body.i, a.body.i);
+      assert.strictEqual(messages[1].body.i, b.body.i);
+    });
+
+    test("should reassemble a data line split across chunks", async () => {
+      const reply = makeMessage();
+      const frame = sseFrame(reply, { id: 1 });
+      // Split mid-data so the parser must buffer across reads
+      const splitAt = frame.indexOf("data: ") + 10;
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks([frame.slice(0, splitAt), frame.slice(splitAt)])),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.i, reply.body.i);
+    });
+
+    test("should reassemble a data line split across many small chunks", async () => {
+      const reply = makeMessage();
+      const frame = sseFrame(reply, { id: 1 });
+      const chunks: string[] = [];
+      for (let i = 0; i < frame.length; i += 7) {
+        chunks.push(frame.slice(i, i + 7));
+      }
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks(chunks)),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.i, reply.body.i);
+    });
+
+    test("should parse a final data line that has no trailing newline", async () => {
+      const reply = makeMessage();
+      // Drop the trailing "\n\n" — common when a server flushes early
+      const frame = `data: ${encodeMessage(reply)}`;
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks([frame])),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.i, reply.body.i);
+    });
+
+    test("should ignore non-data SSE lines (id, event, retry, comments)", async () => {
+      const body = ["id: 1", "event: /credential", "retry: 5000", ": comment", "", ""].join("\n");
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(streamFromChunks([body])),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 0);
+    });
+  });
+});

--- a/src/core/mailbox-client.test.ts
+++ b/src/core/mailbox-client.test.ts
@@ -177,6 +177,31 @@ describe(basename(import.meta.url), () => {
       assert.strictEqual(messages[0].body.i, reply.body.i);
     });
 
+    test("should return without waiting for stream to close once a message is parsed", async () => {
+      const reply = makeMessage();
+      let cancelled = false;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sseFrame(reply, { id: 1 })));
+          // Server keeps the stream open (long-poll); never call controller.close()
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+
+      const client = new MailboxClient({
+        id: "EAID",
+        url: "http://mailbox.example",
+        fetch: async () => eventStreamResponse(stream),
+      });
+
+      const messages = await client.sendMessage(makeMessage());
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.i, reply.body.i);
+      assert.strictEqual(cancelled, true);
+    });
+
     test("should parse a final data line that has no trailing newline", async () => {
       const reply = makeMessage();
       // Drop the trailing "\n\n" — common when a server flushes early

--- a/src/core/mailbox-client.ts
+++ b/src/core/mailbox-client.ts
@@ -61,24 +61,25 @@ export class MailboxClient {
 
     if (contentType === "text/event-stream") {
       const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      const messages: Message[] = [];
+      let buffer = "";
       while (true) {
         const { done, value } = await reader.read();
-
-        if (done) {
-          break;
-        }
-
-        const str = new TextDecoder().decode(value);
-
-        for (const line of str.split("\n")) {
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
           if (line.startsWith("data: ")) {
-            const data = line.slice(6);
-            const message = await Array.fromAsync(parse(data));
-            reader.cancel("Got message, cancelling reader");
-            return message;
+            messages.push(...(await Array.fromAsync(parse(line.slice(6)))));
           }
         }
       }
+      if (buffer.startsWith("data: ")) {
+        messages.push(...(await Array.fromAsync(parse(buffer.slice(6)))));
+      }
+      return messages;
     }
 
     if (contentType?.startsWith("application/json")) {

--- a/src/core/mailbox-client.ts
+++ b/src/core/mailbox-client.ts
@@ -14,12 +14,21 @@ async function parseEventStream(body: ReadableStream<Uint8Array>): Promise<Messa
 
   while (true) {
     const { done, value } = await reader.read();
-    if (done) break;
+    if (done) {
+      break;
+    }
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split("\n");
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       await flushLine(line);
+    }
+
+    // Long-poll SSE servers (e.g. KERIpy) keep the stream open after sending
+    // a snapshot. Once we have at least one message, stop reading and return.
+    if (messages.length > 0) {
+      await reader.cancel();
+      return messages;
     }
   }
   await flushLine(buffer);

--- a/src/core/mailbox-client.ts
+++ b/src/core/mailbox-client.ts
@@ -1,5 +1,31 @@
 import { encodeText, type Message, parse } from "#keri/cesr";
 
+async function parseEventStream(body: ReadableStream<Uint8Array>): Promise<Message[]> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const messages: Message[] = [];
+  let buffer = "";
+
+  async function flushLine(line: string): Promise<void> {
+    if (line.startsWith("data: ")) {
+      messages.push(...(await Array.fromAsync(parse(line.slice(6)))));
+    }
+  }
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      await flushLine(line);
+    }
+  }
+  await flushLine(buffer);
+  return messages;
+}
+
 export interface MailboxClientOptions {
   /**
    * The SAID of the mailbox controller.
@@ -60,26 +86,7 @@ export class MailboxClient {
     }
 
     if (contentType === "text/event-stream") {
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      const messages: Message[] = [];
-      let buffer = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            messages.push(...(await Array.fromAsync(parse(line.slice(6)))));
-          }
-        }
-      }
-      if (buffer.startsWith("data: ")) {
-        messages.push(...(await Array.fromAsync(parse(buffer.slice(6)))));
-      }
-      return messages;
+      return await parseEventStream(response.body);
     }
 
     if (contentType?.startsWith("application/json")) {

--- a/src/mailbox/logger.ts
+++ b/src/mailbox/logger.ts
@@ -1,0 +1,15 @@
+export interface Logger {
+  trace(msg: string, meta?: object): void;
+  debug(msg: string, meta?: object): void;
+  info(msg: string, meta?: object): void;
+  warn(msg: string, meta?: object): void;
+  error(msg: string, meta?: object): void;
+}
+
+export const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};

--- a/src/mailbox/mailbox-router.test.ts
+++ b/src/mailbox/mailbox-router.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert";
+import { basename } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, test } from "node:test";
+import { Attachments, encodeText, parse } from "#keri/cesr";
+import type { Message } from "#keri/core";
+import { generateKeyPair, keri } from "#keri/core";
+import { NodeSqliteDatabase, SqliteControllerStorage } from "#keri/storage/sqlite";
+import { Mailbox } from "./mailbox.ts";
+import { createRouter } from "./mailbox-router.ts";
+
+function makeMailbox(url?: string) {
+  return new Mailbox({
+    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
+    url,
+  });
+}
+
+function makeApp(url?: string) {
+  return createRouter(makeMailbox(url));
+}
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://localhost${path}`, init);
+}
+
+async function parseSse(response: Response): Promise<Message[]> {
+  const text = await response.text();
+  const messages: Message[] = [];
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      messages.push(...(await Array.fromAsync(parse(line.slice(6)))));
+    }
+  }
+  return messages;
+}
+
+function postMessage(message: Message): Request {
+  const atc = new Attachments({
+    ControllerIdxSigs: message.attachments.ControllerIdxSigs,
+    TransIdxSigGroups: message.attachments.TransIdxSigGroups,
+    TransLastIdxSigGroups: message.attachments.TransLastIdxSigGroups,
+    PathedMaterialCouples: message.attachments.PathedMaterialCouples,
+  });
+
+  return request("/", {
+    method: "POST",
+    body: new TextDecoder().decode(message.raw),
+    headers: { "CESR-ATTACHMENT": encodeText(atc.frames()) },
+  });
+}
+
+function makeForward(pre: string, topic: string) {
+  const { publicKey: senderPub } = generateKeyPair();
+  const sender = keri.incept({ signingKeys: [senderPub], nextKeys: [] });
+  const { publicKey: innerPub } = generateKeyPair();
+  const inner = keri.incept({ signingKeys: [innerPub], nextKeys: [] });
+  return keri.exchange({
+    sender: sender.body.i,
+    route: "/fwd",
+    query: { pre, topic },
+    anchor: {},
+    embeds: { evt: inner },
+  });
+}
+
+function makeQuery(id: string, topics: Record<string, number>) {
+  return keri.query({ r: "mbx", q: { i: id, topics } });
+}
+
+describe(basename(import.meta.url), () => {
+  describe("GET /", () => {
+    test("should return 200 with status ok", async () => {
+      const app = makeApp();
+      const response = await app(request("/", { method: "GET" }));
+      assert.strictEqual(response.status, 200);
+      assert.deepStrictEqual(await response.json(), { status: "OK" });
+    });
+  });
+
+  describe("POST /", () => {
+    test("should return 400 when CESR-ATTACHMENT header is missing", async () => {
+      const app = makeApp();
+      const { publicKey } = generateKeyPair();
+      const icp = keri.incept({ signingKeys: [publicKey], nextKeys: [] });
+      const response = await app(
+        request("/", {
+          method: "POST",
+          body: new TextDecoder().decode(icp.raw),
+        }),
+      );
+      assert.strictEqual(response.status, 400);
+    });
+
+    test("should return 204 when no reply messages are produced", async () => {
+      const app = makeApp();
+      const { publicKey } = generateKeyPair();
+      const icp = keri.incept({ signingKeys: [publicKey], nextKeys: [] });
+      const response = await app(postMessage(icp));
+      assert.strictEqual(response.status, 204);
+    });
+
+    test("should return 204 for a /fwd message (store only, no reply)", async () => {
+      const app = makeApp();
+      const fwd = makeForward("some-recipient", "credential");
+      const response = await app(postMessage(fwd));
+      assert.strictEqual(response.status, 204);
+    });
+
+    test("should return 204 for a mbx query when mailbox is empty", async () => {
+      const app = makeApp();
+      const query = makeQuery("unknown-prefix", { "/credential": 0 });
+      const response = await app(postMessage(query));
+      assert.strictEqual(response.status, 204);
+    });
+
+    test("should return stored messages as text/event-stream on mbx query", async () => {
+      const app = createRouter(makeMailbox());
+      const pre = "test-recipient";
+
+      await app(postMessage(makeForward(pre, "credential")));
+      await app(postMessage(makeForward(pre, "credential")));
+
+      const response = await app(postMessage(makeQuery(pre, { "/credential": 0 })));
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get("Content-Type"), "text/event-stream");
+
+      const messages = await parseSse(response);
+      assert.strictEqual(messages.length, 2);
+      assert.strictEqual(messages[0].body.t, "icp");
+      assert.strictEqual(messages[1].body.t, "icp");
+    });
+
+    test("should respect offset in mbx query", async () => {
+      const app = createRouter(makeMailbox());
+      const pre = "test-recipient";
+
+      await app(postMessage(makeForward(pre, "credential")));
+      await app(postMessage(makeForward(pre, "credential")));
+      await app(postMessage(makeForward(pre, "credential")));
+
+      const response = await app(postMessage(makeQuery(pre, { "/credential": 1 })));
+      const messages = await parseSse(response);
+      assert.strictEqual(messages.length, 2);
+    });
+  });
+
+  describe("GET /oobi", () => {
+    test("should return 200 with application/json+cesr content type", async () => {
+      const app = makeApp("http://localhost:5640");
+      const response = await app(request("/oobi", { method: "GET" }));
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get("Content-Type"), "application/json+cesr");
+    });
+
+    test("should include Keri-Aid header with mailbox AID", async () => {
+      const mailbox = makeMailbox("http://localhost:5640");
+      const app = createRouter(mailbox);
+      const response = await app(request("/oobi", { method: "GET" }));
+      assert.strictEqual(response.headers.get("Keri-Aid"), mailbox.aid);
+    });
+
+    test("should return inception event as first message", async () => {
+      const mailbox = makeMailbox("http://localhost:5640");
+      const app = createRouter(mailbox);
+      const response = await app(request("/oobi", { method: "GET" }));
+      const messages = await Array.fromAsync(parse(response.body ?? new Uint8Array()));
+      assert(messages.length > 0);
+      assert.strictEqual(messages[0].body.t, "icp");
+      assert.strictEqual(messages[0].body.i, mailbox.aid);
+    });
+
+    test("should return location record", async () => {
+      const app = makeApp("http://localhost:5640");
+      const response = await app(request("/oobi", { method: "GET" }));
+      const messages = await Array.fromAsync(parse(response.body ?? new Uint8Array()));
+      const loc = messages.find((m) => m.body.r === "/loc/scheme");
+      assert.partialDeepStrictEqual(loc?.body, { t: "rpy", r: "/loc/scheme" });
+    });
+
+    test("should return end role record with mailbox role", async () => {
+      const app = makeApp("http://localhost:5640");
+      const response = await app(request("/oobi", { method: "GET" }));
+      const messages = await Array.fromAsync(parse(response.body ?? new Uint8Array()));
+      const endrole = messages.find((m) => m.body.r === "/end/role/add");
+      assert.partialDeepStrictEqual(endrole?.body, { t: "rpy", r: "/end/role/add" });
+      assert.strictEqual((endrole?.body.a as { role?: string })?.role, "mailbox");
+    });
+
+    test("should return only inception event when no url is configured", async () => {
+      const app = makeApp();
+      const response = await app(request("/oobi", { method: "GET" }));
+      const messages = await Array.fromAsync(parse(response.body ?? new Uint8Array()));
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].body.t, "icp");
+    });
+  });
+
+  describe("unknown routes", () => {
+    test("should return 404 for unknown path", async () => {
+      const app = makeApp();
+      const response = await app(request("/unknown", { method: "GET" }));
+      assert.strictEqual(response.status, 404);
+    });
+
+    test("should return 405 for unsupported method", async () => {
+      const app = makeApp();
+      const response = await app(request("/", { method: "DELETE" }));
+      assert.strictEqual(response.status, 405);
+    });
+  });
+});

--- a/src/mailbox/mailbox-router.ts
+++ b/src/mailbox/mailbox-router.ts
@@ -1,0 +1,107 @@
+import { Attachments, encodeText, parse } from "#keri/cesr";
+import { type Logger, noopLogger } from "./logger.ts";
+import type { Mailbox, MailboxEvent, MailboxReply } from "./mailbox.ts";
+
+const RETRY_MS = 5000;
+
+export interface RouterOptions {
+  logger?: Logger;
+}
+
+function createOobiResponse(events: readonly MailboxEvent[]): Response {
+  const body = events
+    .flatMap(({ message }) => {
+      const atc = new Attachments({
+        ControllerIdxSigs: message.attachments.ControllerIdxSigs,
+        NonTransReceiptCouples: message.attachments.NonTransReceiptCouples,
+      });
+      return [new TextDecoder().decode(message.raw), encodeText(atc.frames())];
+    })
+    .join("");
+
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json+cesr" },
+  });
+}
+
+function encodeReply(reply: MailboxReply): string {
+  const atc = new Attachments({
+    ControllerIdxSigs: reply.message.attachments.ControllerIdxSigs,
+    WitnessIdxSigs: reply.message.attachments.WitnessIdxSigs,
+    NonTransReceiptCouples: reply.message.attachments.NonTransReceiptCouples,
+    TransIdxSigGroups: reply.message.attachments.TransIdxSigGroups,
+    PathedMaterialCouples: reply.message.attachments.PathedMaterialCouples,
+  });
+  const cesr = new TextDecoder().decode(reply.message.raw) + encodeText(atc.frames());
+  return `id: ${reply.id}\nevent: ${reply.topic}\nretry: ${RETRY_MS}\ndata: ${cesr}\n\n`;
+}
+
+function createResponse(replies: readonly MailboxReply[]): Response {
+  if (replies.length === 0) {
+    return new Response(null, { status: 204 });
+  }
+
+  const body = replies.map(encodeReply).join("");
+
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+export function createRouter(mailbox: Mailbox, options: RouterOptions = {}): (request: Request) => Promise<Response> {
+  const log = options.logger ?? noopLogger;
+
+  async function handleMessageRequest(request: Request): Promise<Response> {
+    const atc = request.headers.get("CESR-ATTACHMENT");
+    if (!atc) {
+      log.warn("rejecting POST /: missing CESR-ATTACHMENT");
+      return Response.json({ error: "Bad Request" }, { status: 400 });
+    }
+
+    const bodyText = await request.text();
+    const replies: MailboxReply[] = [];
+    let count = 0;
+    for await (const event of parse(bodyText + atc)) {
+      count++;
+      for await (const reply of mailbox.handleMessage(event)) {
+        replies.push(reply);
+      }
+    }
+
+    log.debug("POST /: handled messages", { count, replies: replies.length });
+    return createResponse(replies);
+  }
+
+  return async function handler(request: Request): Promise<Response> {
+    const { method } = request;
+    const pathname = new URL(request.url).pathname;
+
+    if (pathname === "/") {
+      switch (method) {
+        case "GET":
+          return Response.json({ status: "OK" });
+        case "POST":
+          return handleMessageRequest(request);
+        default:
+          return new Response("Method Not Allowed", { status: 405 });
+      }
+    }
+
+    if (pathname.startsWith("/oobi")) {
+      switch (method) {
+        case "GET": {
+          log.debug("GET /oobi: serving self", { count: mailbox.events.length });
+          const response = createOobiResponse(mailbox.events);
+          response.headers.set("Keri-Aid", mailbox.aid);
+          return response;
+        }
+        default:
+          return new Response("Method Not Allowed", { status: 405 });
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}

--- a/src/mailbox/mailbox.test.ts
+++ b/src/mailbox/mailbox.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert";
+import { basename } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, test } from "node:test";
+import type { Message } from "#keri/cesr";
+import { generateKeyPair, keri } from "#keri/core";
+import { NodeSqliteDatabase, SqliteControllerStorage } from "#keri/storage/sqlite";
+import { Mailbox } from "./mailbox.ts";
+
+function makeMailbox() {
+  return new Mailbox({
+    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
+  });
+}
+
+function makeInnerMessage() {
+  const { publicKey } = generateKeyPair();
+  return keri.incept({ signingKeys: [publicKey], nextKeys: [] });
+}
+
+function makeForward(pre: string, topic: string, inner: Message) {
+  const { publicKey: senderPub } = generateKeyPair();
+  const sender = keri.incept({ signingKeys: [senderPub], nextKeys: [] });
+  return keri.exchange({
+    sender: sender.body.i,
+    route: "/fwd",
+    query: { pre, topic },
+    anchor: {},
+    embeds: { evt: inner },
+  });
+}
+
+function makeQuery(id: string, topics: Record<string, number>) {
+  return keri.query({ r: "mbx", q: { i: id, topics } });
+}
+
+describe(basename(import.meta.url), () => {
+  describe("handleMessage()", () => {
+    test("should be a no-op for unknown message types", async () => {
+      const mailbox = makeMailbox();
+      const icp = makeInnerMessage();
+      const replies = await Array.fromAsync(mailbox.handleMessage(icp));
+      assert.strictEqual(replies.length, 0);
+    });
+
+    describe("/fwd", () => {
+      test("should store the inner evt message", async () => {
+        const mailbox = makeMailbox();
+        const inner = makeInnerMessage();
+        const fwd = makeForward("recipient-prefix", "credential", inner);
+
+        await Array.fromAsync(mailbox.handleMessage(fwd));
+
+        const query = makeQuery("recipient-prefix", { "/credential": 0 });
+        const results = await Array.fromAsync(mailbox.handleMessage(query));
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].topic, "/credential");
+        assert.strictEqual(results[0].message.body.t, inner.body.t);
+        assert.strictEqual(results[0].message.body.d, inner.body.d);
+      });
+
+      test("should be a no-op when pre is missing", async () => {
+        const mailbox = makeMailbox();
+        const { publicKey: senderPub } = generateKeyPair();
+        const sender = keri.incept({ signingKeys: [senderPub], nextKeys: [] });
+        const inner = makeInnerMessage();
+
+        const fwd = keri.exchange({
+          sender: sender.body.i,
+          route: "/fwd",
+          query: { topic: "credential" },
+          anchor: {},
+          embeds: { evt: inner },
+        });
+
+        await Array.fromAsync(mailbox.handleMessage(fwd));
+
+        const query = makeQuery("any-prefix", { "/credential": 0 });
+        const results = await Array.fromAsync(mailbox.handleMessage(query));
+        assert.strictEqual(results.length, 0);
+      });
+    });
+
+    describe("mbx query", () => {
+      test("should return empty for unknown recipient", async () => {
+        const mailbox = makeMailbox();
+        const query = makeQuery("unknown-prefix", { "/credential": 0 });
+        const results = await Array.fromAsync(mailbox.handleMessage(query));
+        assert.strictEqual(results.length, 0);
+      });
+
+      test("should return messages from the given offset", async () => {
+        const mailbox = makeMailbox();
+        const pre = "test-recipient";
+
+        const msg1 = makeInnerMessage();
+        const msg2 = makeInnerMessage();
+        const msg3 = makeInnerMessage();
+
+        await Array.fromAsync(mailbox.handleMessage(makeForward(pre, "credential", msg1)));
+        await Array.fromAsync(mailbox.handleMessage(makeForward(pre, "credential", msg2)));
+        await Array.fromAsync(mailbox.handleMessage(makeForward(pre, "credential", msg3)));
+
+        const all = await Array.fromAsync(mailbox.handleMessage(makeQuery(pre, { "/credential": 0 })));
+        assert.strictEqual(all.length, 3);
+
+        const fromOffset = await Array.fromAsync(mailbox.handleMessage(makeQuery(pre, { "/credential": 1 })));
+        assert.strictEqual(fromOffset.length, 2);
+        assert.strictEqual(fromOffset[0].message.body.d, msg2.body.d);
+        assert.strictEqual(fromOffset[1].message.body.d, msg3.body.d);
+      });
+
+      test("should scope messages by topic", async () => {
+        const mailbox = makeMailbox();
+        const pre = "test-recipient";
+
+        await Array.fromAsync(mailbox.handleMessage(makeForward(pre, "credential", makeInnerMessage())));
+        await Array.fromAsync(mailbox.handleMessage(makeForward(pre, "multisig", makeInnerMessage())));
+
+        const credentials = await Array.fromAsync(mailbox.handleMessage(makeQuery(pre, { "/credential": 0 })));
+        assert.strictEqual(credentials.length, 1);
+
+        const multisig = await Array.fromAsync(mailbox.handleMessage(makeQuery(pre, { "/multisig": 0 })));
+        assert.strictEqual(multisig.length, 1);
+      });
+    });
+  });
+});

--- a/src/mailbox/mailbox.ts
+++ b/src/mailbox/mailbox.ts
@@ -1,0 +1,148 @@
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { encodeText, Indexer, Matter, Message, type MessageBody } from "#keri/cesr";
+import type { ExchangeEventBody, QueryEventBody } from "#keri/core";
+import { KeyEventLog, keri } from "#keri/core";
+import type { MailboxServerStorage } from "#keri/storage";
+import { type Logger, noopLogger } from "./logger.ts";
+
+export interface MailboxOptions {
+  storage: MailboxServerStorage;
+  privateKey?: Uint8Array;
+  url?: string;
+  logger?: Logger;
+}
+
+export interface MailboxEvent {
+  readonly message: Message;
+  readonly timestamp: Date;
+}
+
+export interface MailboxReply {
+  readonly id: number;
+  readonly topic: string;
+  readonly message: Message;
+}
+
+export class Mailbox {
+  readonly #storage: MailboxServerStorage;
+  readonly #privateKey: Uint8Array;
+  readonly #kel: KeyEventLog;
+  readonly #log: Logger;
+  readonly events: readonly MailboxEvent[];
+
+  static createKEL(privateKey: Uint8Array): KeyEventLog {
+    const publicKey = encodeText(new Matter({ code: Matter.Code.Ed25519N, raw: ed25519.getPublicKey(privateKey) }));
+    const icp = keri.incept({ signingKeys: [publicKey], nextKeys: [] });
+    icp.attachments = {
+      ControllerIdxSigs: [encodeText(Indexer.crypto.ed25519_sig(ed25519.sign(icp.raw, privateKey), 0))],
+    };
+    return KeyEventLog.from([icp]);
+  }
+
+  get aid(): string {
+    return this.#kel.state.identifier;
+  }
+
+  constructor(options: MailboxOptions) {
+    this.#storage = options.storage;
+    this.#privateKey = options.privateKey ?? ed25519.utils.randomSecretKey();
+    this.#kel = Mailbox.createKEL(this.#privateKey);
+    this.#log = options.logger ?? noopLogger;
+
+    const events: MailboxEvent[] = [{ message: this.#kel.events[0], timestamp: new Date() }];
+
+    if (options.url) {
+      const url = new URL(options.url);
+      const scheme = url.protocol.replace(":", "");
+
+      const location = keri.reply({
+        r: "/loc/scheme",
+        a: { eid: this.aid, scheme, url: options.url },
+      });
+
+      const endrole = keri.reply({
+        r: "/end/role/add",
+        a: { cid: this.aid, role: "mailbox", eid: this.aid },
+      });
+
+      location.attachments = {
+        NonTransReceiptCouples: [{ prefix: this.aid, sig: this.#sign(location) }],
+      };
+
+      endrole.attachments = {
+        NonTransReceiptCouples: [{ prefix: this.aid, sig: this.#sign(endrole) }],
+      };
+
+      events.push({ message: location, timestamp: new Date() });
+      events.push({ message: endrole, timestamp: new Date() });
+    }
+
+    this.events = events;
+  }
+
+  async *handleMessage(message: Message): AsyncGenerator<MailboxReply> {
+    const { t, r } = message.body as { t?: string; r?: string };
+
+    if (t === "exn" && r === "/fwd") {
+      this.#log.debug("handling exn /fwd");
+      this.#handleForward(message as Message<ExchangeEventBody>);
+      return;
+    }
+
+    if (t === "qry" && r === "mbx") {
+      this.#log.debug("handling qry mbx");
+      yield* this.#handleQuery(message as Message<QueryEventBody>);
+      return;
+    }
+
+    this.#log.debug("ignoring message", { t, r });
+  }
+
+  #handleForward(message: Message<ExchangeEventBody>): void {
+    const { q, e } = message.body;
+    const pre = q.pre as string | undefined;
+    const topic = q.topic as string | undefined;
+
+    if (!pre || !topic) {
+      this.#log.warn("ignoring forward: missing q.pre or q.topic");
+      return;
+    }
+
+    const evtBody = e?.evt as MessageBody | undefined;
+    if (!evtBody) {
+      this.#log.warn("ignoring forward: missing e.evt", { pre, topic });
+      return;
+    }
+
+    const evtCouple = message.attachments.PathedMaterialCouples.find((c) => c.path === "-e-evt");
+    const innerMessage = new Message(evtBody, evtCouple?.attachments);
+
+    this.#log.debug("saving mailbox entry", { pre, topic });
+    this.#storage.saveMailboxEntry(pre, topic, innerMessage);
+  }
+
+  *#handleQuery(message: Message<QueryEventBody>): Generator<MailboxReply> {
+    const { i, topics } = message.body.q as {
+      i?: string;
+      topics?: Record<string, number>;
+    };
+
+    if (!i || !topics) {
+      this.#log.warn("ignoring query: missing q.i or q.topics");
+      return;
+    }
+
+    this.#log.debug("querying mailbox", { aid: i, topics });
+    for (const [topicPath, offset] of Object.entries(topics)) {
+      const storageTopic = topicPath.replace(/^\//, "");
+      for (const entry of this.#storage.getMailboxEntries(i, storageTopic, offset)) {
+        yield { id: entry.id, topic: topicPath, message: entry.message };
+      }
+    }
+  }
+
+  #sign(message: Message): string {
+    const rawSignature = ed25519.sign(message.raw, this.#privateKey);
+    return encodeText(new Matter({ code: Matter.Code.Ed25519_Sig, raw: rawSignature }));
+  }
+}

--- a/src/mailbox/main.ts
+++ b/src/mailbox/main.ts
@@ -1,0 +1,3 @@
+export type { Logger } from "./logger.ts";
+export { Mailbox } from "./mailbox.ts";
+export { createRouter as createMailboxRouter, type RouterOptions } from "./mailbox-router.ts";

--- a/src/nodejs-utils/logger.ts
+++ b/src/nodejs-utils/logger.ts
@@ -1,0 +1,15 @@
+export interface Logger {
+  trace(msg: string, meta?: object): void;
+  debug(msg: string, meta?: object): void;
+  info(msg: string, meta?: object): void;
+  warn(msg: string, meta?: object): void;
+  error(msg: string, meta?: object): void;
+}
+
+export const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};

--- a/src/nodejs-utils/main.ts
+++ b/src/nodejs-utils/main.ts
@@ -1,0 +1,2 @@
+export { type Logger, noopLogger } from "./logger.ts";
+export { createListener, type ListenerOptions } from "./serve.ts";

--- a/src/nodejs-utils/serve.test.ts
+++ b/src/nodejs-utils/serve.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import type { Logger } from "./logger.ts";
+import { createListener, type ListenerOptions } from "./serve.ts";
+
+interface TestServer extends AsyncDisposable {
+  url: string;
+}
+
+async function startServer(
+  handler: (request: Request) => Promise<Response>,
+  options?: ListenerOptions,
+): Promise<TestServer> {
+  const server = createServer(createListener(handler, options));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    async [Symbol.asyncDispose]() {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    },
+  };
+}
+
+function makeRecordingLogger(): { logger: Logger; entries: { level: string; msg: string; meta?: object }[] } {
+  const entries: { level: string; msg: string; meta?: object }[] = [];
+  const make = (level: string) => (msg: string, meta?: object) => {
+    entries.push({ level, msg, meta });
+  };
+  return {
+    entries,
+    logger: {
+      trace: make("trace"),
+      debug: make("debug"),
+      info: make("info"),
+      warn: make("warn"),
+      error: make("error"),
+    },
+  };
+}
+
+function recordRequest(response: Response = new Response(null, { status: 204 })) {
+  const captured: { request?: Request } = {};
+  const handler = async (req: Request) => {
+    captured.request = req;
+    return response.clone();
+  };
+  return { captured, handler };
+}
+
+describe(basename(import.meta.url), () => {
+  test("forwards method, path, and query to the handler", async () => {
+    const { captured, handler } = recordRequest(new Response("ok", { status: 200 }));
+    await using server = await startServer(handler);
+
+    const response = await fetch(`${server.url}/foo/bar?x=1&y=2`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(await response.text(), "ok");
+    assert.ok(captured.request);
+    assert.strictEqual(captured.request.method, "GET");
+    const url = new URL(captured.request.url);
+    assert.strictEqual(url.pathname, "/foo/bar");
+    assert.strictEqual(url.searchParams.get("x"), "1");
+    assert.strictEqual(url.searchParams.get("y"), "2");
+  });
+
+  test("forwards request headers to the handler", async () => {
+    const { captured, handler } = recordRequest();
+    await using server = await startServer(handler);
+
+    await fetch(`${server.url}/`, {
+      headers: { "x-custom-header": "abc", "content-type": "application/json" },
+    });
+    assert.ok(captured.request);
+    assert.strictEqual(captured.request.headers.get("x-custom-header"), "abc");
+    assert.strictEqual(captured.request.headers.get("content-type"), "application/json");
+  });
+
+  test("forwards POST body to the handler", async () => {
+    let body: string | undefined;
+    await using server = await startServer(async (req) => {
+      body = await req.text();
+      return new Response(null, { status: 204 });
+    });
+
+    await fetch(`${server.url}/`, {
+      method: "POST",
+      body: "hello world",
+      headers: { "content-type": "text/plain" },
+    });
+    assert.strictEqual(body, "hello world");
+  });
+
+  test("does not forward a body for GET requests", async () => {
+    const { captured, handler } = recordRequest();
+    await using server = await startServer(handler);
+
+    await fetch(`${server.url}/`);
+    assert.ok(captured.request);
+    assert.strictEqual(captured.request.body, null);
+  });
+
+  test("forwards response status, headers, and body", async () => {
+    await using server = await startServer(
+      async () =>
+        new Response("response body", {
+          status: 201,
+          headers: { "content-type": "text/plain", "x-extra": "value" },
+        }),
+    );
+
+    const response = await fetch(`${server.url}/`);
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(response.headers.get("content-type"), "text/plain");
+    assert.strictEqual(response.headers.get("x-extra"), "value");
+    assert.strictEqual(await response.text(), "response body");
+  });
+
+  test("supports streamed response bodies", async () => {
+    await using server = await startServer(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("chunk1"));
+          controller.enqueue(new TextEncoder().encode("chunk2"));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "content-type": "text/plain" } });
+    });
+
+    const response = await fetch(`${server.url}/`);
+    assert.strictEqual(await response.text(), "chunk1chunk2");
+  });
+
+  test("returns 500 when the handler throws", async () => {
+    await using server = await startServer(async () => {
+      throw new Error("boom");
+    });
+
+    const response = await fetch(`${server.url}/`);
+    assert.strictEqual(response.status, 500);
+    assert.strictEqual(await response.text(), "Internal Server Error");
+  });
+
+  test("uses x-forwarded-proto when constructing the request URL", async () => {
+    const { captured, handler } = recordRequest();
+    await using server = await startServer(handler);
+
+    await fetch(`${server.url}/`, { headers: { "x-forwarded-proto": "https" } });
+    assert.ok(captured.request);
+    assert.ok(captured.request.url.startsWith("https://"));
+  });
+
+  test("logs request completion at info level with structured meta", async () => {
+    const { logger, entries } = makeRecordingLogger();
+    await using server = await startServer(async () => new Response("ok", { status: 200 }), { logger });
+
+    await fetch(`${server.url}/some-path?x=1`, { headers: { "x-trace": "abc" } });
+
+    const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET /some-path?x=1 200 "));
+    assert.ok(completed, "expected an info-level completion log");
+    assert.match(completed.msg, /^GET \/some-path\?x=1 200 \d+ms$/);
+    const meta = completed.meta as { method: string; url: string; status: number; durationMs: number };
+    assert.strictEqual(meta.method, "GET");
+    assert.strictEqual(meta.url, "/some-path?x=1");
+    assert.strictEqual(meta.status, 200);
+    assert.ok(typeof meta.durationMs === "number");
+  });
+
+  test("logs status 500 when the handler throws", async () => {
+    const { logger, entries } = makeRecordingLogger();
+    await using server = await startServer(
+      async () => {
+        throw new Error("boom");
+      },
+      { logger },
+    );
+
+    const response = await fetch(`${server.url}/`);
+    assert.strictEqual(response.status, 500);
+
+    const errored = entries.find((e) => e.level === "error" && e.msg === "handler threw");
+    assert.ok(errored, "expected an error-level log when the handler throws");
+    const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET / 500 "));
+    assert.ok(completed, "expected a completion log with status 500");
+  });
+});

--- a/src/nodejs-utils/serve.test.ts
+++ b/src/nodejs-utils/serve.test.ts
@@ -6,8 +6,9 @@ import { describe, test } from "node:test";
 import type { Logger } from "./logger.ts";
 import { createListener, type ListenerOptions } from "./serve.ts";
 
-interface TestServer extends AsyncDisposable {
+interface TestServer {
   url: string;
+  close(): Promise<void>;
 }
 
 async function startServer(
@@ -19,7 +20,7 @@ async function startServer(
   const { port } = server.address() as AddressInfo;
   return {
     url: `http://127.0.0.1:${port}`,
-    async [Symbol.asyncDispose]() {
+    async close() {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     },
   };
@@ -54,73 +55,88 @@ function recordRequest(response: Response = new Response(null, { status: 204 }))
 describe(basename(import.meta.url), () => {
   test("forwards method, path, and query to the handler", async () => {
     const { captured, handler } = recordRequest(new Response("ok", { status: 200 }));
-    await using server = await startServer(handler);
-
-    const response = await fetch(`${server.url}/foo/bar?x=1&y=2`);
-    assert.strictEqual(response.status, 200);
-    assert.strictEqual(await response.text(), "ok");
-    assert.ok(captured.request);
-    assert.strictEqual(captured.request.method, "GET");
-    const url = new URL(captured.request.url);
-    assert.strictEqual(url.pathname, "/foo/bar");
-    assert.strictEqual(url.searchParams.get("x"), "1");
-    assert.strictEqual(url.searchParams.get("y"), "2");
+    const server = await startServer(handler);
+    try {
+      const response = await fetch(`${server.url}/foo/bar?x=1&y=2`);
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(await response.text(), "ok");
+      assert.ok(captured.request);
+      assert.strictEqual(captured.request.method, "GET");
+      const url = new URL(captured.request.url);
+      assert.strictEqual(url.pathname, "/foo/bar");
+      assert.strictEqual(url.searchParams.get("x"), "1");
+      assert.strictEqual(url.searchParams.get("y"), "2");
+    } finally {
+      await server.close();
+    }
   });
 
   test("forwards request headers to the handler", async () => {
     const { captured, handler } = recordRequest();
-    await using server = await startServer(handler);
-
-    await fetch(`${server.url}/`, {
-      headers: { "x-custom-header": "abc", "content-type": "application/json" },
-    });
-    assert.ok(captured.request);
-    assert.strictEqual(captured.request.headers.get("x-custom-header"), "abc");
-    assert.strictEqual(captured.request.headers.get("content-type"), "application/json");
+    const server = await startServer(handler);
+    try {
+      await fetch(`${server.url}/`, {
+        headers: { "x-custom-header": "abc", "content-type": "application/json" },
+      });
+      assert.ok(captured.request);
+      assert.strictEqual(captured.request.headers.get("x-custom-header"), "abc");
+      assert.strictEqual(captured.request.headers.get("content-type"), "application/json");
+    } finally {
+      await server.close();
+    }
   });
 
   test("forwards POST body to the handler", async () => {
     let body: string | undefined;
-    await using server = await startServer(async (req) => {
+    const server = await startServer(async (req) => {
       body = await req.text();
       return new Response(null, { status: 204 });
     });
-
-    await fetch(`${server.url}/`, {
-      method: "POST",
-      body: "hello world",
-      headers: { "content-type": "text/plain" },
-    });
-    assert.strictEqual(body, "hello world");
+    try {
+      await fetch(`${server.url}/`, {
+        method: "POST",
+        body: "hello world",
+        headers: { "content-type": "text/plain" },
+      });
+      assert.strictEqual(body, "hello world");
+    } finally {
+      await server.close();
+    }
   });
 
   test("does not forward a body for GET requests", async () => {
     const { captured, handler } = recordRequest();
-    await using server = await startServer(handler);
-
-    await fetch(`${server.url}/`);
-    assert.ok(captured.request);
-    assert.strictEqual(captured.request.body, null);
+    const server = await startServer(handler);
+    try {
+      await fetch(`${server.url}/`);
+      assert.ok(captured.request);
+      assert.strictEqual(captured.request.body, null);
+    } finally {
+      await server.close();
+    }
   });
 
   test("forwards response status, headers, and body", async () => {
-    await using server = await startServer(
+    const server = await startServer(
       async () =>
         new Response("response body", {
           status: 201,
           headers: { "content-type": "text/plain", "x-extra": "value" },
         }),
     );
-
-    const response = await fetch(`${server.url}/`);
-    assert.strictEqual(response.status, 201);
-    assert.strictEqual(response.headers.get("content-type"), "text/plain");
-    assert.strictEqual(response.headers.get("x-extra"), "value");
-    assert.strictEqual(await response.text(), "response body");
+    try {
+      const response = await fetch(`${server.url}/`);
+      assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get("content-type"), "text/plain");
+      assert.strictEqual(response.headers.get("x-extra"), "value");
+      assert.strictEqual(await response.text(), "response body");
+    } finally {
+      await server.close();
+    }
   });
 
   test("supports streamed response bodies", async () => {
-    await using server = await startServer(async () => {
+    const server = await startServer(async () => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(new TextEncoder().encode("chunk1"));
@@ -130,61 +146,76 @@ describe(basename(import.meta.url), () => {
       });
       return new Response(stream, { status: 200, headers: { "content-type": "text/plain" } });
     });
-
-    const response = await fetch(`${server.url}/`);
-    assert.strictEqual(await response.text(), "chunk1chunk2");
+    try {
+      const response = await fetch(`${server.url}/`);
+      assert.strictEqual(await response.text(), "chunk1chunk2");
+    } finally {
+      await server.close();
+    }
   });
 
   test("returns 500 when the handler throws", async () => {
-    await using server = await startServer(async () => {
+    const server = await startServer(async () => {
       throw new Error("boom");
     });
-
-    const response = await fetch(`${server.url}/`);
-    assert.strictEqual(response.status, 500);
-    assert.strictEqual(await response.text(), "Internal Server Error");
+    try {
+      const response = await fetch(`${server.url}/`);
+      assert.strictEqual(response.status, 500);
+      assert.strictEqual(await response.text(), "Internal Server Error");
+    } finally {
+      await server.close();
+    }
   });
 
   test("uses x-forwarded-proto when constructing the request URL", async () => {
     const { captured, handler } = recordRequest();
-    await using server = await startServer(handler);
-
-    await fetch(`${server.url}/`, { headers: { "x-forwarded-proto": "https" } });
-    assert.ok(captured.request);
-    assert.ok(captured.request.url.startsWith("https://"));
+    const server = await startServer(handler);
+    try {
+      await fetch(`${server.url}/`, { headers: { "x-forwarded-proto": "https" } });
+      assert.ok(captured.request);
+      assert.ok(captured.request.url.startsWith("https://"));
+    } finally {
+      await server.close();
+    }
   });
 
   test("logs request completion at info level with structured meta", async () => {
     const { logger, entries } = makeRecordingLogger();
-    await using server = await startServer(async () => new Response("ok", { status: 200 }), { logger });
+    const server = await startServer(async () => new Response("ok", { status: 200 }), { logger });
+    try {
+      await fetch(`${server.url}/some-path?x=1`, { headers: { "x-trace": "abc" } });
 
-    await fetch(`${server.url}/some-path?x=1`, { headers: { "x-trace": "abc" } });
-
-    const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET /some-path?x=1 200 "));
-    assert.ok(completed, "expected an info-level completion log");
-    assert.match(completed.msg, /^GET \/some-path\?x=1 200 \d+ms$/);
-    const meta = completed.meta as { method: string; url: string; status: number; durationMs: number };
-    assert.strictEqual(meta.method, "GET");
-    assert.strictEqual(meta.url, "/some-path?x=1");
-    assert.strictEqual(meta.status, 200);
-    assert.ok(typeof meta.durationMs === "number");
+      const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET /some-path?x=1 200 "));
+      assert.ok(completed, "expected an info-level completion log");
+      assert.match(completed.msg, /^GET \/some-path\?x=1 200 \d+ms$/);
+      const meta = completed.meta as { method: string; url: string; status: number; durationMs: number };
+      assert.strictEqual(meta.method, "GET");
+      assert.strictEqual(meta.url, "/some-path?x=1");
+      assert.strictEqual(meta.status, 200);
+      assert.ok(typeof meta.durationMs === "number");
+    } finally {
+      await server.close();
+    }
   });
 
   test("logs status 500 when the handler throws", async () => {
     const { logger, entries } = makeRecordingLogger();
-    await using server = await startServer(
+    const server = await startServer(
       async () => {
         throw new Error("boom");
       },
       { logger },
     );
+    try {
+      const response = await fetch(`${server.url}/`);
+      assert.strictEqual(response.status, 500);
 
-    const response = await fetch(`${server.url}/`);
-    assert.strictEqual(response.status, 500);
-
-    const errored = entries.find((e) => e.level === "error" && e.msg === "handler threw");
-    assert.ok(errored, "expected an error-level log when the handler throws");
-    const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET / 500 "));
-    assert.ok(completed, "expected a completion log with status 500");
+      const errored = entries.find((e) => e.level === "error" && e.msg === "handler threw");
+      assert.ok(errored, "expected an error-level log when the handler throws");
+      const completed = entries.find((e) => e.level === "info" && e.msg.startsWith("GET / 500 "));
+      assert.ok(completed, "expected a completion log with status 500");
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/src/nodejs-utils/serve.ts
+++ b/src/nodejs-utils/serve.ts
@@ -1,8 +1,16 @@
-import type { IncomingMessage, RequestListener, ServerResponse } from "node:http";
+import type { IncomingMessage, RequestListener } from "node:http";
 import { Readable } from "node:stream";
-import { format } from "node:util";
+import { type Logger, noopLogger } from "./logger.ts";
 
-function toWebRequest(req: IncomingMessage, url: URL): Request {
+export interface ListenerOptions {
+  logger?: Logger;
+}
+
+function toWebRequest(req: IncomingMessage): Request {
+  const host = req.headers.host ?? "0.0.0.0";
+  const protocol = req.headers["x-forwarded-proto"] ?? "http";
+  const url = new URL(req.url ?? "/", `${protocol}://${host}`);
+
   const headers = new Headers();
   for (const [key, headerValue] of Object.entries(req.headers)) {
     if (headerValue !== undefined) {
@@ -21,74 +29,51 @@ function toWebRequest(req: IncomingMessage, url: URL): Request {
     body = Readable.toWeb(req) as ReadableStream<Uint8Array>;
   }
 
-  const request = new Request(url, {
+  return new Request(url, {
     method: req.method,
-    headers: headers,
+    headers,
     body,
     duplex: "half",
     // Cast required because DOM types omit `duplex`, but Node.js undici fetch requires it when body is a stream
   } as RequestInit & { duplex: "half" });
-
-  return request;
-}
-
-export interface ServerOptions {
-  logger?: (message: string, context?: unknown) => void;
-}
-
-async function handleRequest(
-  req: IncomingMessage,
-  res: ServerResponse<IncomingMessage>,
-  handler: (request: Request) => Promise<Response>,
-): Promise<void> {
-  const host = req.headers.host ?? "0.0.0.0";
-  const protocol = req.headers["x-forwarded-proto"] ?? "http";
-  const url = new URL(req.url ?? "/", `${protocol}://${host}`);
-  const request = toWebRequest(req, url);
-  const response = await handler(request);
-
-  res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
-
-  const reader = response.body?.getReader();
-  if (reader) {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      res.write(value);
-    }
-  }
-  res.end();
 }
 
 export function createListener(
   handler: (request: Request) => Promise<Response>,
-  logger?: (message: string, context?: unknown) => void,
+  options: ListenerOptions = {},
 ): RequestListener {
+  const log = options.logger ?? noopLogger;
+
   return async (req, res) => {
     const start = Date.now();
-    const url = req.url ?? "/";
     const method = req.method ?? "GET";
-    logger?.(`${method} ${url}`);
+    const url = req.url ?? "/";
 
     res.on("finish", () => {
-      const ms = Date.now() - start;
-
-      logger?.(`${method} ${url} - ${res.statusCode} - ${ms}ms`, {
-        request: {
-          url,
-          method,
-          headers: req.headers,
-        },
-        response: {
-          status: res.statusCode,
-        },
+      const durationMs = Date.now() - start;
+      log.info(`${method} ${url} ${res.statusCode} ${durationMs}ms`, {
+        method,
+        url,
+        status: res.statusCode,
+        durationMs,
       });
     });
 
     try {
-      await handleRequest(req, res, handler);
+      const response = await handler(toWebRequest(req));
+      res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+
+      if (response.body) {
+        const reader = response.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          res.write(value);
+        }
+      }
+      res.end();
     } catch (err) {
-      logger?.(`Error handling request\n${format(err)}\n`);
+      log.error("handler threw", { method, url, error: err instanceof Error ? err.message : String(err) });
       res.statusCode = 500;
       res.end("Internal Server Error");
     }

--- a/src/storage/mailbox-server-storage.ts
+++ b/src/storage/mailbox-server-storage.ts
@@ -1,0 +1,11 @@
+import type { Message } from "#keri/cesr";
+
+export interface MailboxEntry {
+  id: number;
+  message: Message;
+}
+
+export interface MailboxServerStorage {
+  saveMailboxEntry(pre: string, topic: string, message: Message): void;
+  getMailboxEntries(pre: string, topic: string, offset: number): Generator<MailboxEntry>;
+}

--- a/src/storage/main.ts
+++ b/src/storage/main.ts
@@ -1,4 +1,5 @@
 export type { CredentialStorage } from "./credential-storage.ts";
 export type { KeyEventStorage } from "./key-event-storage.ts";
+export type { MailboxEntry, MailboxServerStorage } from "./mailbox-server-storage.ts";
 export type { MailboxStorage } from "./mailbox-storage.ts";
 export type { PrivateKeyStorage } from "./private-key-storage.ts";

--- a/src/storage/sqlite/schema.ts
+++ b/src/storage/sqlite/schema.ts
@@ -32,6 +32,18 @@ const migrations: string[][] = [
       ")",
     ].join("\n"),
   ],
+  // Migration 3: mailbox entry (server-side message store)
+  [
+    [
+      "CREATE TABLE IF NOT EXISTS mailbox_entry (",
+      "  id          INTEGER PRIMARY KEY AUTOINCREMENT,",
+      "  pre         TEXT NOT NULL,",
+      "  topic       TEXT NOT NULL,",
+      "  event_json  JSON NOT NULL,",
+      "  attachments TEXT",
+      ")",
+    ].join("\n"),
+  ],
 ];
 
 export function migrate(db: Database): void {

--- a/src/storage/sqlite/storage-sqlite.ts
+++ b/src/storage/sqlite/storage-sqlite.ts
@@ -18,6 +18,7 @@ import {
 } from "#keri/core";
 import type { CredentialStorage } from "../credential-storage.ts";
 import type { KeyEventStorage } from "../key-event-storage.ts";
+import type { MailboxEntry, MailboxServerStorage } from "../mailbox-server-storage.ts";
 import type { MailboxStorage } from "../mailbox-storage.ts";
 import type { PrivateKeyStorage } from "../private-key-storage.ts";
 
@@ -110,7 +111,9 @@ function prepareRow<T extends MessageBody>(message: Message<T>): RowInput {
   }
 }
 
-export class SqliteControllerStorage implements KeyEventStorage, PrivateKeyStorage, CredentialStorage, MailboxStorage {
+export class SqliteControllerStorage
+  implements KeyEventStorage, PrivateKeyStorage, CredentialStorage, MailboxStorage, MailboxServerStorage
+{
   #db: Database;
 
   constructor(db: Database) {
@@ -287,5 +290,33 @@ export class SqliteControllerStorage implements KeyEventStorage, PrivateKeyStora
         "ON CONFLICT(prefix, topic) DO UPDATE SET offset = $offset",
       { prefix, topic, offset },
     );
+  }
+
+  saveMailboxEntry(pre: string, topic: string, message: Message): void {
+    this.#db.execute(
+      "INSERT INTO mailbox_entry(pre, topic, event_json, attachments) VALUES ($pre, $topic, $event_json, $attachments)",
+      {
+        pre,
+        topic,
+        event_json: JSON.stringify(message.body),
+        attachments: encodeText(message.attachments.frames()),
+      },
+    );
+  }
+
+  *getMailboxEntries(pre: string, topic: string, offset: number): Generator<MailboxEntry> {
+    const statement = [
+      "SELECT id, event_json, attachments FROM mailbox_entry",
+      "WHERE pre = $pre AND topic = $topic AND id > $offset",
+      "ORDER BY id ASC",
+    ].join("\n");
+
+    for (const row of this.#db.iterate(statement, { pre, topic, offset })) {
+      const id = row.id;
+      if (typeof id !== "number") {
+        throw new Error("mailbox_entry.id missing or not a number");
+      }
+      yield { id, message: parseRow(row) };
+    }
   }
 }

--- a/src/witness/logger.ts
+++ b/src/witness/logger.ts
@@ -1,0 +1,15 @@
+export interface Logger {
+  trace(msg: string, meta?: object): void;
+  debug(msg: string, meta?: object): void;
+  info(msg: string, meta?: object): void;
+  warn(msg: string, meta?: object): void;
+  error(msg: string, meta?: object): void;
+}
+
+export const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};

--- a/src/witness/main.ts
+++ b/src/witness/main.ts
@@ -1,2 +1,3 @@
+export type { Logger } from "./logger.ts";
 export { Witness, WitnessError, type WitnessEvent, type WitnessOptions } from "./witness.ts";
-export { createRouter } from "./witness-router.ts";
+export { createRouter, type RouterOptions } from "./witness-router.ts";

--- a/src/witness/witness-router.ts
+++ b/src/witness/witness-router.ts
@@ -1,6 +1,11 @@
 import { Attachments, encodeText, parse } from "#keri/cesr";
 import type { KeyEvent, KeyEventBody } from "#keri/core";
+import { type Logger, noopLogger } from "./logger.ts";
 import { type Witness, WitnessError, type WitnessEvent } from "./witness.ts";
+
+export interface RouterOptions {
+  logger?: Logger;
+}
 
 function createResponse(events: readonly WitnessEvent[]): Response {
   const body = events
@@ -21,10 +26,13 @@ function createResponse(events: readonly WitnessEvent[]): Response {
   });
 }
 
-export function createRouter(witness: Witness): (request: Request) => Promise<Response> {
+export function createRouter(witness: Witness, options: RouterOptions = {}): (request: Request) => Promise<Response> {
+  const log = options.logger ?? noopLogger;
+
   async function handleReceiptRequest(request: Request): Promise<Response> {
     const atc = request.headers.get("CESR-ATTACHMENT");
     if (!atc) {
+      log.warn("rejecting POST /receipts: missing CESR-ATTACHMENT");
       return Response.json({ error: "Bad Request" }, { status: 400 });
     }
 
@@ -37,12 +45,14 @@ export function createRouter(witness: Witness): (request: Request) => Promise<Re
         receipts.push({ message: receipt, timestamp: new Date() });
       } catch (err) {
         if (err instanceof WitnessError) {
+          log.warn("rejecting POST /receipts", { error: err.message });
           return Response.json({ error: "Bad Request" }, { status: 400 });
         }
         throw err;
       }
     }
 
+    log.debug("POST /receipts: issued receipts", { count: receipts.length });
     return createResponse(receipts);
   }
 
@@ -51,13 +61,20 @@ export function createRouter(witness: Witness): (request: Request) => Promise<Re
     const aid = url.pathname.split("/")[2];
     let response: Response;
     if (aid === undefined || aid === witness.aid) {
+      log.debug("GET /oobi: serving self", { count: witness.events.length });
       response = createResponse(witness.events);
     } else {
       const events = Array.from(witness.getKeyEvents(aid)).map((event) => ({
         message: event,
         timestamp: event.attachments.FirstSeenReplayCouples[0]?.dt ?? new Date(0),
       }));
-      response = events.length === 0 ? new Response("Not Found", { status: 404 }) : createResponse(events);
+      if (events.length === 0) {
+        log.debug("GET /oobi: not found", { aid });
+        response = new Response("Not Found", { status: 404 });
+      } else {
+        log.debug("GET /oobi: serving events", { aid, count: events.length });
+        response = createResponse(events);
+      }
     }
     response.headers.set("Keri-Aid", witness.aid);
     return response;
@@ -66,14 +83,18 @@ export function createRouter(witness: Witness): (request: Request) => Promise<Re
   async function handleMessageRequest(request: Request): Promise<Response> {
     const atc = request.headers.get("CESR-ATTACHMENT");
     if (!atc) {
+      log.warn("rejecting POST /: missing CESR-ATTACHMENT");
       return Response.json({ error: "Bad Request" }, { status: 400 });
     }
 
     const bodyText = await request.text();
+    let count = 0;
     for await (const event of parse(bodyText + atc)) {
       witness.handleMessage(event);
+      count++;
     }
 
+    log.debug("POST /: handled messages", { count });
     return new Response(null, { status: 200 });
   }
 

--- a/src/witness/witness.ts
+++ b/src/witness/witness.ts
@@ -2,11 +2,13 @@ import { ed25519 } from "@noble/curves/ed25519.js";
 import { Attachments, encodeText, Indexer, Matter, Message } from "#keri/cesr";
 import { type KeyEvent, type KeyEventBody, KeyEventLog, keri, type ReceiptEventBody } from "#keri/core";
 import type { KeyEventStorage } from "#keri/storage";
+import { type Logger, noopLogger } from "./logger.ts";
 
 export interface WitnessOptions {
   privateKey?: Uint8Array;
   url?: string;
   storage: KeyEventStorage;
+  logger?: Logger;
 }
 
 export interface WitnessEvent {
@@ -22,6 +24,7 @@ export class Witness {
   readonly #storage: KeyEventStorage;
   readonly #privateKey: Uint8Array;
   readonly #kel: KeyEventLog;
+  readonly #log: Logger;
 
   get aid() {
     return this.#kel.state.identifier;
@@ -45,6 +48,7 @@ export class Witness {
     this.#storage = options.storage;
     this.#privateKey = options.privateKey ?? ed25519.utils.randomSecretKey();
     this.#kel = Witness.createKEL(this.#privateKey);
+    this.#log = options.logger ?? noopLogger;
 
     const events: WitnessEvent[] = [{ message: this.#kel.events[0], timestamp: new Date() }];
 
@@ -89,10 +93,12 @@ export class Witness {
     const body = message.body;
 
     if (typeof body.i !== "string" || typeof body.d !== "string" || typeof body.s !== "string") {
+      this.#log.warn("rejecting receipt: missing required fields i/d/s");
       throw new WitnessError("Missing required fields i, d, s");
     }
 
     if (message.attachments.ControllerIdxSigs.length === 0) {
+      this.#log.warn("rejecting receipt: no controller signatures", { aid: body.i, s: body.s, d: body.d });
       throw new WitnessError("Missing controller signatures");
     }
 
@@ -102,9 +108,17 @@ export class Witness {
       kel = kel.append(message, { allowPartiallyWitnessed: true });
     } catch (error) {
       if (error instanceof Error) {
+        this.#log.warn("rejecting receipt: KEL append failed", {
+          aid: body.i,
+          s: body.s,
+          d: body.d,
+          error: error.message,
+        });
         throw new WitnessError(`Failed to append message to KEL: ${error.message}`);
       }
     }
+
+    this.#log.debug("issuing receipt", { aid: body.i, s: body.s, d: body.d });
 
     const sig = this.#sign(message);
     const witnessIndex = kel.state.backers.indexOf(this.aid);
@@ -131,10 +145,12 @@ export class Witness {
     const body = message.body as KeyEventBody;
 
     if (body.t !== "rct") {
+      this.#log.debug("ignoring message: only rct handled", { t: body.t });
       return;
     }
 
     if (typeof body.i !== "string" || typeof body.d !== "string") {
+      this.#log.warn("ignoring receipt: missing i/d");
       return;
     }
 
@@ -144,11 +160,13 @@ export class Witness {
     });
 
     if (!kel.state.backers.includes(this.aid)) {
+      this.#log.debug("ignoring receipt: not a backer", { aid: body.i, d: body.d });
       return;
     }
 
     const storedEvent = kel.events.find((event) => event.body.d === body.d);
     if (!storedEvent) {
+      this.#log.debug("ignoring receipt: no matching stored event", { aid: body.i, d: body.d });
       return;
     }
 
@@ -173,6 +191,7 @@ export class Witness {
       FirstSeenReplayCouples: storedEvent.attachments.FirstSeenReplayCouples,
     });
 
+    this.#log.debug("merged witness sigs", { aid: body.i, d: body.d, count: existingWigsByIndex.size });
     this.#storage.saveMessage(new Message(storedEvent.body, mergedAttachments));
   }
 

--- a/test_interop/test_challenge_respond.ts
+++ b/test_interop/test_challenge_respond.ts
@@ -2,10 +2,10 @@ import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { keri } from "#keri/core";
 import { KERIPy } from "./keripy.ts";
-import { createController, startKeripyWitness, type Witness } from "./utils.ts";
+import { createController, type Endpoint, startKeripyWitness } from "./utils.ts";
 
-let wan: Witness;
-let wil: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
 const abortController = new AbortController();
 
 before(async () => {

--- a/test_interop/test_credential_issuance.ts
+++ b/test_interop/test_credential_issuance.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { KERIPy } from "./keripy.ts";
-import { createController, startKeripyWitness, type Witness } from "./utils.ts";
+import { createController, type Endpoint, startKeripyWitness } from "./utils.ts";
 
 const QVI_SCHEMA = "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao";
 const LE_SCHEMA = "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY";
@@ -16,8 +16,8 @@ const RULES = {
   },
 };
 
-let wan: Witness;
-let wil: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
 const abortController = new AbortController();
 
 before(async () => {

--- a/test_interop/test_credential_receipt.ts
+++ b/test_interop/test_credential_receipt.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { KERIPy } from "./keripy.ts";
-import { createController, startKeripyWitness, type Witness } from "./utils.ts";
+import { createController, type Endpoint, startKeripyWitness } from "./utils.ts";
 
 const SCHEMA_SAID = "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao";
 
-let wan: Witness;
-let wil: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
 const abortController = new AbortController();
 
 before(async () => {

--- a/test_interop/test_keripy_witness.ts
+++ b/test_interop/test_keripy_witness.ts
@@ -1,6 +1,6 @@
+import { parse } from "#keri/cesr";
 import assert from "node:assert";
 import test, { after, before } from "node:test";
-import { parse } from "#keri/cesr";
 import { KERIPy } from "./keripy.ts";
 import {
   collectAsync,
@@ -73,7 +73,7 @@ test("Create identifier with single witness", async () => {
   });
 });
 
-test.only("Create kerijs identifier with single witness", async () => {
+test("Create kerijs identifier with single witness", async () => {
   const controller = createController();
 
   await controller.introduce(wan.oobi);

--- a/test_interop/test_keripy_witness.ts
+++ b/test_interop/test_keripy_witness.ts
@@ -1,6 +1,6 @@
-import { parse } from "#keri/cesr";
 import assert from "node:assert";
 import test, { after, before } from "node:test";
+import { parse } from "#keri/cesr";
 import { KERIPy } from "./keripy.ts";
 import {
   collectAsync,

--- a/test_interop/test_keripy_witness.ts
+++ b/test_interop/test_keripy_witness.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert";
+import test, { after, before } from "node:test";
+import { parse } from "#keri/cesr";
+import { KERIPy } from "./keripy.ts";
+import {
+  collectAsync,
+  createController,
+  type Endpoint,
+  type KeripyWitness,
+  startKerijsMailbox,
+  startKeripyWitness,
+} from "./utils.ts";
+
+let wan: KeripyWitness;
+let wes: KeripyWitness;
+let mailbox: Endpoint;
+const abortController = new AbortController();
+
+before(async () => {
+  [wan, wes, mailbox] = await Promise.all([
+    startKeripyWitness({ signal: abortController.signal }),
+    startKeripyWitness({ signal: abortController.signal }),
+    startKerijsMailbox({ signal: abortController.signal }),
+  ]);
+});
+
+after(() => {
+  abortController.abort();
+});
+
+test("Create identifier with single witness", async () => {
+  const keripy = new KERIPy();
+  await keripy.init();
+  await keripy.oobi.resolve(wan.oobi, "wan");
+
+  await wan.kli.oobi.resolve(wes.oobi, "wes");
+  await keripy.oobi.resolve(wes.oobi, "wes");
+
+  await keripy.incept({ wits: [wan.aid], toad: 1, receiptEndpoint: true });
+  const aid = await keripy.aid();
+
+  await keripy.ends.add({ eid: wes.aid, role: "mailbox" });
+
+  const response = await fetch(`${wan.url}/oobi/${aid}/mailbox`);
+  assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  assert(parsed.length >= 3, "Expected at least 3 messages in response");
+  assert.partialDeepStrictEqual(parsed[0].body, {
+    t: "icp",
+    d: aid,
+    i: aid,
+    s: "0",
+  });
+  assert.partialDeepStrictEqual(parsed[1].body, {
+    t: "rpy",
+    r: "/loc/scheme",
+    a: {
+      eid: wes.aid,
+      scheme: "http",
+      url: wes.url,
+    },
+  });
+  assert.partialDeepStrictEqual(parsed[2].body, {
+    t: "rpy",
+    r: "/end/role/add",
+    a: {
+      cid: aid,
+      role: "mailbox",
+      eid: wes.aid,
+    },
+  });
+});
+
+test.only("Create kerijs identifier with single witness", async () => {
+  const controller = createController();
+
+  await controller.introduce(wan.oobi);
+  await controller.introduce(wes.oobi);
+  await controller.introduce(mailbox.oobi);
+
+  await wan.kli.oobi.resolve(mailbox.oobi, "wil");
+
+  const state = await controller.incept({ wits: [wan.aid], toad: 1 });
+  const aid = state.id;
+
+  await controller.reply({
+    id: state.id,
+    route: "/end/role/add",
+    record: {
+      cid: state.id,
+      role: "mailbox",
+      eid: mailbox.aid,
+    },
+  });
+
+  const response = await fetch(`${wan.url}/oobi/${state.id}/mailbox`);
+  assert.equal(response.status, 200);
+  assert(response.body, "Expected response body");
+
+  const parsed = await collectAsync(parse(response.body));
+  for (const message of parsed) {
+    console.log(message);
+  }
+  assert(parsed.length >= 3, "Expected at least 3 messages in response");
+  assert.partialDeepStrictEqual(parsed[0].body, {
+    t: "icp",
+    d: aid,
+    i: aid,
+    s: "0",
+  });
+  assert.partialDeepStrictEqual(parsed[1].body, {
+    t: "rpy",
+    r: "/loc/scheme",
+    a: {
+      eid: mailbox.aid,
+      scheme: "http",
+      url: mailbox.url,
+    },
+  });
+  assert.partialDeepStrictEqual(parsed[2].body, {
+    t: "rpy",
+    r: "/end/role/add",
+    a: {
+      cid: aid,
+      role: "mailbox",
+      eid: mailbox.aid,
+    },
+  });
+});

--- a/test_interop/test_mailbox.ts
+++ b/test_interop/test_mailbox.ts
@@ -1,0 +1,107 @@
+import { keri } from "#keri/core";
+import assert from "node:assert";
+import test, { after, before } from "node:test";
+import { KERIPy } from "./keripy.ts";
+import { createController, type Endpoint, startKerijsMailbox, startKeripyWitness } from "./utils.ts";
+
+let witness: Endpoint;
+let mailbox: Endpoint;
+const abortController = new AbortController();
+
+before(async () => {
+  // TODO: replace the KERIpy witness with a kerijs witness once supported
+  [witness, mailbox] = await Promise.all([
+    startKeripyWitness({ signal: abortController.signal }),
+    startKerijsMailbox({ signal: abortController.signal }),
+  ]);
+});
+
+after(() => {
+  abortController.abort();
+});
+
+test("forward exchange through mailbox", async () => {
+  const alice = createController();
+  const bob = createController();
+
+  await alice.introduce(witness.oobi);
+  await bob.introduce(witness.oobi);
+
+  const aliceState = await alice.incept({ wits: [witness.aid], toad: 1 });
+  const bobState = await bob.incept({ wits: [witness.aid], toad: 1 });
+
+  await alice.introduce(mailbox.oobi);
+  await alice.reply({
+    id: aliceState.id,
+    route: "/end/role/add",
+    record: { cid: aliceState.id, eid: mailbox.aid, role: "mailbox" },
+  });
+
+  await bob.introduce(mailbox.oobi);
+  await bob.introduce(`${witness.url}/oobi/${aliceState.id}/mailbox`);
+  await alice.introduce(`${witness.url}/oobi/${bobState.id}/mailbox`);
+
+  const words = ["bob", "to", "alice"];
+
+  await bob.forward({
+    message: keri.exchange({
+      sender: bobState.id,
+      route: "/challenge/response",
+      query: {},
+      anchor: { i: bobState.id, words },
+      embeds: {},
+    }),
+    recipient: aliceState.id,
+    sender: bobState.id,
+    topic: "challenge",
+  });
+
+  const inbox = await alice.query(aliceState.id, "challenge");
+  assert.equal(inbox.length, 1);
+  assert.equal(inbox[0].body.t, "exn");
+  assert.deepEqual(inbox[0].body.a, { i: bobState.id, words });
+});
+
+test("KERIpy controller receives forwarded exchange via KERIjs mailbox", async () => {
+  const alice = new KERIPy();
+  await alice.init();
+  await alice.oobi.resolve(witness.oobi, "wit");
+  await alice.incept({ wits: [witness.aid], toad: 1 });
+
+  await alice.oobi.resolve(mailbox.oobi, "mbx");
+  await alice.ends.add({ eid: mailbox.aid });
+
+  const aliceAid = await alice.aid();
+
+  const bob = createController();
+  await bob.introduce(witness.oobi);
+  await bob.introduce(mailbox.oobi);
+
+  const bobState = await bob.incept({ wits: [witness.aid], toad: 1 });
+
+  await bob.reply({
+    id: bobState.id,
+    route: "/end/role/add",
+    record: { cid: bobState.id, eid: mailbox.aid, role: "mailbox" },
+  });
+
+  await bob.introduce(`${witness.url}/oobi/${aliceAid}/mailbox`);
+  await alice.oobi.resolve(`${witness.url}/oobi/${bobState.id}/mailbox`, "bob");
+
+  const words = await alice.challenge.generate();
+
+  await bob.forward({
+    message: keri.exchange({
+      sender: bobState.id,
+      route: "/challenge/response",
+      query: {},
+      anchor: { i: bobState.id, words },
+      embeds: {},
+    }),
+    recipient: aliceAid,
+    sender: bobState.id,
+    topic: "challenge",
+  });
+
+  await alice.challenge.verify({ words, signer: "bob" });
+});

--- a/test_interop/test_mailbox.ts
+++ b/test_interop/test_mailbox.ts
@@ -1,6 +1,6 @@
-import { keri } from "#keri/core";
 import assert from "node:assert";
 import test, { after, before } from "node:test";
+import { keri } from "#keri/core";
 import { KERIPy } from "./keripy.ts";
 import { createController, type Endpoint, startKerijsMailbox, startKeripyWitness } from "./utils.ts";
 

--- a/test_interop/test_witness_kerijs.ts
+++ b/test_interop/test_witness_kerijs.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { parse } from "#keri/cesr";
-import { collectAsync, createController, startKerijsWitness, type Witness } from "./utils.ts";
+import { collectAsync, createController, type Endpoint, startKerijsWitness } from "./utils.ts";
 
-let wan: Witness;
-let wil: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
 
 const abortController = new AbortController();
 

--- a/test_interop/test_witness_keripy_controller.ts
+++ b/test_interop/test_witness_keripy_controller.ts
@@ -2,10 +2,10 @@ import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { parse } from "#keri/cesr";
 import { KERIPy } from "./keripy.ts";
-import { collectAsync, startKerijsWitness, type Witness } from "./utils.ts";
+import { collectAsync, type Endpoint, startKerijsWitness } from "./utils.ts";
 
-let wan: Witness;
-let wil: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
 const abortController = new AbortController();
 
 before(async () => {

--- a/test_interop/test_witness_receipt.ts
+++ b/test_interop/test_witness_receipt.ts
@@ -2,11 +2,11 @@ import assert from "node:assert";
 import test, { after, before } from "node:test";
 import { parse } from "#keri/cesr";
 import { keri, submitToWitnesses } from "#keri/core";
-import { collectAsync, createController, startKeripyWitness, type Witness } from "./utils.ts";
+import { collectAsync, createController, type Endpoint, startKeripyWitness } from "./utils.ts";
 
-let wan: Witness;
-let wil: Witness;
-let wes: Witness;
+let wan: Endpoint;
+let wil: Endpoint;
+let wes: Endpoint;
 const abortController = new AbortController();
 
 before(async () => {

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -1,15 +1,20 @@
+import { Controller } from "#keri";
+import { createMailboxRouter, Mailbox } from "#keri/mailbox";
+import { createListener, type Logger } from "#keri/nodejs-utils";
+import { NodeSqliteDatabase, SqliteControllerStorage } from "#keri/storage/sqlite";
+import { createRouter, Witness } from "#keri/witness";
 import { createServer } from "node:http";
 import { DatabaseSync } from "node:sqlite";
-import { Controller } from "#keri";
-import { createListener } from "#keri/nodejs-utils";
-import { NodeSqliteDatabase, SqliteControllerStorage } from "#keri/storage/sqlite";
-import { createRouter, Witness as WitnessNode } from "#keri/witness";
 import { KERIPy } from "./keripy.ts";
 
-export interface Witness {
+export interface Endpoint {
   aid: string;
   url: string;
   oobi: string;
+}
+
+export interface KeripyWitness extends Endpoint {
+  kli: KERIPy;
 }
 
 export function createController() {
@@ -38,22 +43,16 @@ function findFreePort(): Promise<number> {
   });
 }
 
-export async function startKerijsWitness(opts: { port?: number; signal?: AbortSignal } = {}): Promise<Witness> {
-  const port = opts.port ?? (await findFreePort());
-  const url = `http://localhost:${port}`;
+const serverLogger: Logger = {
+  trace: (msg, meta) => console.log(`[server] ${msg}`, meta ?? ""),
+  debug: (msg, meta) => console.log(`[server] ${msg}`, meta ?? ""),
+  info: (msg, meta) => console.log(`[server] ${msg}`, meta ?? ""),
+  warn: (msg, meta) => console.warn(`[server] ${msg}`, meta ?? ""),
+  error: (msg, meta) => console.error(`[server] ${msg}`, meta ?? ""),
+};
 
-  const witness = new WitnessNode({
-    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
-    url: `http://localhost:${port}`,
-  });
-
-  const router = createRouter(witness);
-  const listener = createListener(router, (message, context) => {
-    const prefix = `[kerijs witness]`;
-    console.log(`${prefix} ${message}`, context);
-  });
-
-  const server = createServer(listener);
+async function serve(router: (request: Request) => Promise<Response>, port: number, signal?: AbortSignal) {
+  const server = createServer(createListener(router, { logger: serverLogger }));
 
   await new Promise<void>((resolve, reject) => {
     const onListening = () => {
@@ -70,16 +69,46 @@ export async function startKerijsWitness(opts: { port?: number; signal?: AbortSi
     server.listen(port);
   });
 
-  opts.signal?.addEventListener("abort", () => {
+  signal?.addEventListener("abort", () => {
     server.close();
   });
+}
+
+export async function startKerijsWitness(opts: { port?: number; signal?: AbortSignal } = {}): Promise<Endpoint> {
+  const port = opts.port ?? (await findFreePort());
+  const url = `http://localhost:${port}`;
+
+  const witness = new Witness({
+    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
+    url: `http://localhost:${port}`,
+  });
+
+  const router = createRouter(witness, { logger: serverLogger });
+
+  await serve(router, port, opts.signal);
 
   return { aid: witness.aid, url, oobi: `${url}/oobi` };
 }
 
+export async function startKerijsMailbox(opts: { port?: number; signal?: AbortSignal } = {}): Promise<Endpoint> {
+  const port = opts.port ?? (await findFreePort());
+  const url = `http://localhost:${port}`;
+
+  const mailbox = new Mailbox({
+    storage: new SqliteControllerStorage(new NodeSqliteDatabase(new DatabaseSync(":memory:"))),
+    url: `http://localhost:${port}`,
+  });
+
+  const router = createMailboxRouter(mailbox, { logger: serverLogger });
+
+  await serve(router, port, opts.signal);
+
+  return { aid: mailbox.aid, url, oobi: `${url}/oobi` };
+}
+
 export async function startKeripyWitness(
   opts: { port?: number; salt?: string; signal?: AbortSignal; logLevel?: string } = {},
-): Promise<Witness> {
+): Promise<KeripyWitness> {
   const httpPort = opts.port ?? (await findFreePort());
   const tcpPort = await findFreePort();
   const url = `http://localhost:${httpPort}`;
@@ -116,7 +145,7 @@ export async function startKeripyWitness(
     throw new Error(`KERIpy witness at ${oobiUrl} did not become reachable within 30s`);
   }
 
-  return { aid, url, oobi: oobiUrl };
+  return { aid, url, oobi: oobiUrl, kli: keripy };
 }
 
 export async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -1,10 +1,10 @@
+import { createServer } from "node:http";
+import { DatabaseSync } from "node:sqlite";
 import { Controller } from "#keri";
 import { createMailboxRouter, Mailbox } from "#keri/mailbox";
 import { createListener, type Logger } from "#keri/nodejs-utils";
 import { NodeSqliteDatabase, SqliteControllerStorage } from "#keri/storage/sqlite";
 import { createRouter, Witness } from "#keri/witness";
-import { createServer } from "node:http";
-import { DatabaseSync } from "node:sqlite";
 import { KERIPy } from "./keripy.ts";
 
 export interface Endpoint {


### PR DESCRIPTION
## Summary
- Initial proof-of-concept mailbox: routing, in-memory/sqlite-backed storage, and `/oobi` self-introduction.
- KERIpy interop test (`test_interop/test_mailbox.ts`) for `exn /fwd` and `qry mbx` flows.
- `scripts/serve-mailbox.ts` standalone runner, mirroring `serve-witness.ts`.

**Note:** still PoC — signature verification and KEL verification are not yet implemented.