### PR TITLE
refactor: discriminate event body types and add type guards

### DIFF
--- a/src/controller/controller.test.ts
+++ b/src/controller/controller.test.ts
@@ -517,6 +517,41 @@ describe(basename(import.meta.url), () => {
     });
   });
 
+  describe("processMessage", () => {
+    test("should route a mixed stream of icp, rpy, and vcp to the correct storage paths", async () => {
+      const producer = createController();
+      const consumer = createController();
+
+      // Produce a real signed icp from the producer's KEL.
+      const icp = await producer.incept();
+      const [icpMessage] = Array.from(producer.storage.getKeyEvents(icp.id));
+      assert.ok(icpMessage, "expected producer to have stored the icp");
+
+      const rpy = keri.reply({
+        r: "/loc/scheme",
+        a: { eid: icp.id, scheme: "http", url: "http://example.com" },
+      });
+
+      const vcp = keri.registry({ ii: icp.id });
+
+      await consumer.processMessage(icpMessage);
+      await consumer.processMessage(rpy);
+      await consumer.processMessage(vcp);
+
+      const storedKel = Array.from(consumer.storage.getKeyEvents(icp.id));
+      assert.equal(storedKel.length, 1, "icp should be stored under its AID");
+      assert.equal(storedKel[0].body.d, icp.event.d);
+
+      const storedReplies = Array.from(consumer.storage.getReplies({ route: "/loc/scheme" }));
+      assert.equal(storedReplies.length, 1, "rpy should be stored");
+      assert.equal(storedReplies[0].body.d, rpy.body.d);
+
+      const storedRegistry = consumer.storage.getRegistry(vcp.body.i);
+      assert.ok(storedRegistry, "vcp should be retrievable as a registry");
+      assert.equal(storedRegistry.body.d, vcp.body.d);
+    });
+  });
+
   describe("endpoint", () => {
     test("should resolve mailbox client", () => {
       const cid = "AID_CONTACT_1";

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -4,20 +4,19 @@ import {
   type CredentialBody,
   type DipEventBody,
   type Endpoint,
-  type ExchangeEventBody,
   type InceptEventBody,
   type InteractEventBody,
   type IssueEvent,
-  isKelEventType,
+  isExchange,
+  isKeyEvent,
+  isReply,
   type KeyEvent,
-  type KeyEventBody,
   KeyEventLog,
   type KeyState,
   keri,
   MailboxClient,
   Message,
   type RegistryInceptEventBody,
-  type ReplyEventBody,
   type RotateEventBody,
   resolveEndRole,
   resolveLocation,
@@ -157,14 +156,14 @@ export class Controller {
       throw new Error(`No body in response`);
     }
 
-    const kelMessages: Message<KeyEventBody>[] = [];
+    const kelMessages: KeyEvent[] = [];
     const otherMessages: Message[] = [];
 
     for await (const message of parse(response.body)) {
-      if (isKelEventType(message.body.t)) {
-        kelMessages.push(message as Message<KeyEventBody>);
-      } else if (message.body.t === "rpy") {
-        otherMessages.push(new Message(message.body as ReplyEventBody));
+      if (isKeyEvent(message)) {
+        kelMessages.push(message);
+      } else if (isReply(message)) {
+        otherMessages.push(new Message(message.body));
       }
     }
 
@@ -237,13 +236,12 @@ export class Controller {
       toad: args.toad,
     });
 
-    const body = event.body as InceptEventBody;
-    this.#log.debug("incept: created", { aid: body.i, wits: body.b?.length ?? 0 });
+    this.#log.debug("incept: created", { aid: event.body.i, wits: event.body.b?.length ?? 0 });
     await this.commit(KeyEventLog.empty(), event);
 
     return {
-      id: body.i,
-      event: body,
+      id: event.body.i,
+      event: event.body,
     };
   }
 
@@ -293,25 +291,22 @@ export class Controller {
       return;
     }
 
-    switch (message.body.t) {
-      case "icp":
-      case "rot":
-      case "ixn":
-      case "dip":
-      case "drt": {
-        const body = message.body as KeyEventBody;
-        const log = KeyEventLog.from(this.#storage.getKeyEvents(body.i));
+    if (isKeyEvent(message)) {
+      const { t, i, s, d } = message.body;
+      const log = KeyEventLog.from(this.#storage.getKeyEvents(i));
 
-        // TODO: Detect duplicituous key events
-        if (!log.events.find((event) => event.body.d === message.body.d)) {
-          log.append(message as Message<KeyEventBody>); // throws if verification fails
-          this.#storage.saveMessage(message);
-          this.#log.debug("processMessage: appended key event", { t: body.t, aid: body.i, s: body.s, d: body.d });
-        } else {
-          this.#log.debug("processMessage: duplicate key event ignored", { t: body.t, aid: body.i, d: body.d });
-        }
-        break;
+      // TODO: Detect duplicituous key events
+      if (!log.events.find((event) => event.body.d === d)) {
+        log.append(message); // throws if verification fails
+        this.#storage.saveMessage(message);
+        this.#log.debug("processMessage: appended key event", { t, aid: i, s, d });
+      } else {
+        this.#log.debug("processMessage: duplicate key event ignored", { t, aid: i, d });
       }
+      return;
+    }
+
+    switch (message.body.t) {
       case "vcp":
       case "iss":
       case "rev":
@@ -333,10 +328,16 @@ export class Controller {
   }
 
   async commit(log: KeyEventLog, event: KeyEvent): Promise<void> {
-    const body = event.body as KeyEventBody;
-    const isInception = body.t === "icp" || body.t === "dip";
-    const signingKeys = isInception ? (event.body as InceptEventBody).k : log.state.signingKeys;
-    const backers = isInception ? ((event.body as InceptEventBody).b ?? []) : (log.state.backers ?? []);
+    const body = event.body;
+    let signingKeys: string[];
+    let backers: string[];
+    if (body.t === "icp" || body.t === "dip") {
+      signingKeys = body.k;
+      backers = body.b ?? [];
+    } else {
+      signingKeys = log.state.signingKeys;
+      backers = log.state.backers ?? [];
+    }
     const sigs = await this.sign(event.raw, signingKeys);
     event.attachments.ControllerIdxSigs.push(...sigs);
     this.#log.debug("commit: submitting to witnesses", {
@@ -356,12 +357,12 @@ export class Controller {
     const log = await this.loadEventLog(id);
     const event = keri.interact(log.state, { data: anchor.data });
 
-    this.#log.debug("anchor: created interaction", { aid: id, s: (event.body as InteractEventBody).s });
+    this.#log.debug("anchor: created interaction", { aid: id, s: event.body.s });
     await this.commit(log, event);
 
     return {
-      id: (event.body as InteractEventBody).i,
-      event: event.body as InteractEventBody,
+      id: event.body.i,
+      event: event.body,
     };
   }
 
@@ -380,12 +381,12 @@ export class Controller {
       data: args.data,
     });
 
-    this.#log.debug("rotate: created rotation", { aid: id, s: (event.body as RotateEventBody).s });
+    this.#log.debug("rotate: created rotation", { aid: id, s: event.body.s });
     await this.commit(log, event);
 
     return {
-      id: (event.body as RotateEventBody).i,
-      event: event.body as RotateEventBody,
+      id: event.body.i,
+      event: event.body,
     };
   }
 
@@ -609,8 +610,8 @@ export class Controller {
     return iss;
   }
 
-  private getAnchorFromSeal(aid: string, digest: string): Message<KeyEventBody> {
-    const log = KeyEventLog.from(this.#storage.getKeyEvents(aid) as Iterable<Message<KeyEventBody>>);
+  private getAnchorFromSeal(aid: string, digest: string): KeyEvent {
+    const log = KeyEventLog.from(this.#storage.getKeyEvents(aid));
     const anchor = log.events.find((message) => message.body.d === digest);
 
     if (!anchor) {
@@ -842,10 +843,10 @@ export class Controller {
     const credentials: CredentialBody[] = [];
 
     for (const message of messages) {
-      const body = message.body as ExchangeEventBody;
-      if (body.t !== "exn" || body.r !== "/ipex/grant") {
+      if (!isExchange(message) || message.body.r !== "/ipex/grant") {
         continue;
       }
+      const body = message.body;
 
       const acdcBody = body.e?.acdc as CredentialBody | undefined;
       const issBody = body.e?.iss as IssueEvent | undefined;

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -338,7 +338,9 @@ export class Controller {
       signingKeys = log.state.signingKeys;
       backers = log.state.backers ?? [];
     }
+
     const sigs = await this.sign(event.raw, signingKeys);
+
     event.attachments.ControllerIdxSigs.push(...sigs);
     this.#log.debug("commit: submitting to witnesses", {
       t: body.t,

--- a/src/core/key-event-log.ts
+++ b/src/core/key-event-log.ts
@@ -1,12 +1,14 @@
 import { type Attachments, Message, parse } from "../cesr/main.ts";
-import type {
-  DipEventBody,
-  DrtEventBody,
-  InceptEventBody,
-  InteractEventBody,
-  KeyEventBody,
-  KeyState,
-  RotateEventBody,
+import {
+  type DipEventBody,
+  type DrtEventBody,
+  type InceptEventBody,
+  type InteractEventBody,
+  isKeyEvent,
+  type KeyEvent,
+  type KeyEventBody,
+  type KeyState,
+  type RotateEventBody,
 } from "./key-event.ts";
 import { verifySignaturesOrThrow, verifyThresholdOrThrow } from "./verify.ts";
 
@@ -56,7 +58,7 @@ export class KeyEventLog {
     return new KeyEventLog([], null);
   }
 
-  static from(events: Iterable<Message<KeyEventBody>>, options?: AppendOptions): KeyEventLog {
+  static from(events: Iterable<KeyEvent>, options?: AppendOptions): KeyEventLog {
     let log = KeyEventLog.empty();
     for (const event of events) {
       log = log.append(event, options);
@@ -77,11 +79,11 @@ export class KeyEventLog {
    * leaf (ambiguous — e.g. two unrelated AIDs).
    */
   static async parse(stream: AsyncIterable<Uint8Array>, options?: AppendOptions): Promise<KeyEventLog> {
-    const messages: Message<KeyEventBody>[] = [];
+    const messages: KeyEvent[] = [];
     for await (const message of parse(stream)) {
-      // TODO: Verify that the message is a valid KeyEventBody before casting
-      if (isKelEventType(message.body.t)) {
-        messages.push(message as Message<KeyEventBody>);
+      // Shallow guard: matches on `t`. Structural + SAID validation is done later in append().
+      if (isKeyEvent(message)) {
+        messages.push(message);
       }
     }
     return KeyEventLog.fromMessages(messages, options);
@@ -92,8 +94,8 @@ export class KeyEventLog {
    * messages — useful when the caller has already consumed the stream
    * (e.g. to split KEL events from `rpy` messages in the same response).
    */
-  static fromMessages(messages: Iterable<Message<KeyEventBody>>, options?: AppendOptions): KeyEventLog {
-    const byAid = new Map<string, Message<KeyEventBody>[]>();
+  static fromMessages(messages: Iterable<KeyEvent>, options?: AppendOptions): KeyEventLog {
+    const byAid = new Map<string, KeyEvent[]>();
     for (const m of messages) {
       let list = byAid.get(m.body.i);
       if (!list) {
@@ -107,14 +109,14 @@ export class KeyEventLog {
       return KeyEventLog.empty();
     }
     if (byAid.size === 1) {
-      return KeyEventLog.from(byAid.values().next().value as Message<KeyEventBody>[], options);
+      return KeyEventLog.from(byAid.values().next().value as KeyEvent[], options);
     }
 
     const referencedAsDelegator = new Set<string>();
     for (const events of byAid.values()) {
       const dip = events.find((e) => e.body.t === "dip");
-      if (dip && typeof (dip.body as DipEventBody).di === "string") {
-        referencedAsDelegator.add((dip.body as DipEventBody).di);
+      if (dip && dip.body.t === "dip") {
+        referencedAsDelegator.add(dip.body.di);
       }
     }
 
@@ -131,7 +133,7 @@ export class KeyEventLog {
       let delegator: KeyEventLog | undefined;
       const first = events[0];
       if (first && first.body.t === "dip") {
-        const delegatorAid = (first.body as DipEventBody).di;
+        const delegatorAid = first.body.di;
         if (byAid.has(delegatorAid)) {
           delegator = buildFor(delegatorAid);
         }
@@ -175,27 +177,26 @@ export class KeyEventLog {
           throw new Error("State already initialized");
         }
 
-        const icp = body as InceptEventBody;
-        if (!icp.k || !Array.isArray(icp.k) || icp.k.length === 0) {
+        if (!body.k || !Array.isArray(body.k) || body.k.length === 0) {
           throw new Error("Inception event must have at least one key");
         }
 
         verifySigning(bodyRaw, {
-          keys: icp.k,
-          threshold: icp.kt,
+          keys: body.k,
+          threshold: body.kt,
           sigs,
         });
 
-        if (icp.b && Array.isArray(icp.b) && icp.b.length > 0) {
+        if (body.b && Array.isArray(body.b) && body.b.length > 0) {
           verifyWitness(bodyRaw, {
-            keys: icp.b,
-            threshold: icp.bt,
+            keys: body.b,
+            threshold: body.bt,
             sigs: wigs,
           });
         }
 
         if (body.t === "dip" && delegator) {
-          verifyDelegationAnchor(body as DipEventBody, message.attachments, delegator);
+          verifyDelegationAnchor(body, message.attachments, delegator);
         }
         break;
       }
@@ -221,12 +222,10 @@ export class KeyEventLog {
         }
 
         if (body.t === "drt" && delegator) {
-          verifyDelegationAnchor(body as DrtEventBody, message.attachments, delegator);
+          verifyDelegationAnchor(body, message.attachments, delegator);
         }
         break;
       }
-      default:
-        throw new Error(`Unsupported event type: ${body.t}`);
     }
 
     const newState = reduceKeyState(this.#state, body);
@@ -267,8 +266,8 @@ function verifyDelegationAnchor(
   // for any event whose `a` field anchors this dip/drt — keripy's wire
   // format relies on the verifier deriving the anchor from the delegator's
   // KEL directly when the couple isn't transmitted.
-  const matchingSeal = (event: Message<KeyEventBody>) => {
-    const anchors = (event.body as { a?: KeyEventSeal[] }).a ?? [];
+  const matchingSeal = (event: KeyEvent) => {
+    const anchors = (event.body.a ?? []) as KeyEventSeal[];
     return anchors.some((seal) => seal.i === body.i && seal.s === body.s && seal.d === body.d);
   };
 
@@ -317,58 +316,48 @@ function merge(a: KeyState, b: Partial<KeyState>): KeyState {
 
 function reduceKeyState(state: KeyState | null, body: KeyEventBody): KeyState {
   switch (body.t) {
-    case "icp": {
-      const icp = body as InceptEventBody;
+    case "icp":
       return {
-        identifier: icp.i,
-        signingThreshold: icp.kt,
-        signingKeys: icp.k,
-        nextThreshold: icp.nt,
-        nextKeyDigests: icp.n,
-        backerThreshold: icp.bt,
-        backers: icp.b,
-        configTraits: icp.c,
-        lastEvent: { i: icp.i, s: icp.s, d: icp.d },
-        lastEstablishment: { i: icp.i, s: icp.s, d: icp.d },
+        identifier: body.i,
+        signingThreshold: body.kt,
+        signingKeys: body.k,
+        nextThreshold: body.nt,
+        nextKeyDigests: body.n,
+        backerThreshold: body.bt,
+        backers: body.b,
+        configTraits: body.c,
+        lastEvent: { i: body.i, s: body.s, d: body.d },
+        lastEstablishment: { i: body.i, s: body.s, d: body.d },
       };
-    }
-    case "dip": {
-      const dip = body as DipEventBody;
+    case "dip":
       return {
-        identifier: dip.i,
-        signingThreshold: dip.kt,
-        signingKeys: dip.k,
-        nextThreshold: dip.nt,
-        nextKeyDigests: dip.n,
-        backerThreshold: dip.bt,
-        backers: dip.b,
-        configTraits: dip.c,
-        delegator: dip.di,
-        lastEvent: { i: dip.i, s: dip.s, d: dip.d },
-        lastEstablishment: { i: dip.i, s: dip.s, d: dip.d },
+        identifier: body.i,
+        signingThreshold: body.kt,
+        signingKeys: body.k,
+        nextThreshold: body.nt,
+        nextKeyDigests: body.n,
+        backerThreshold: body.bt,
+        backers: body.b,
+        configTraits: body.c,
+        delegator: body.di,
+        lastEvent: { i: body.i, s: body.s, d: body.d },
+        lastEstablishment: { i: body.i, s: body.s, d: body.d },
       };
-    }
-    case "ixn": {
+    case "ixn":
       assertDefined(state);
-      const ixn = body as InteractEventBody;
-      return merge(state, { lastEvent: { i: ixn.i, s: ixn.s, d: ixn.d } });
-    }
+      return merge(state, { lastEvent: { i: body.i, s: body.s, d: body.d } });
     case "rot":
-    case "drt": {
+    case "drt":
       assertDefined(state);
-      const rot = body as RotateEventBody | DrtEventBody;
       return merge(state, {
-        backers: state.backers.filter((b) => !rot.br.includes(b)).concat(rot.ba),
-        backerThreshold: rot.bt,
-        signingKeys: rot.k,
-        signingThreshold: rot.kt,
-        nextKeyDigests: rot.n,
-        nextThreshold: rot.nt,
-        lastEvent: { i: rot.i, s: rot.s, d: rot.d },
-        lastEstablishment: { i: rot.i, s: rot.s, d: rot.d },
+        backers: state.backers.filter((b) => !body.br.includes(b)).concat(body.ba),
+        backerThreshold: body.bt,
+        signingKeys: body.k,
+        signingThreshold: body.kt,
+        nextKeyDigests: body.n,
+        nextThreshold: body.nt,
+        lastEvent: { i: body.i, s: body.s, d: body.d },
+        lastEstablishment: { i: body.i, s: body.s, d: body.d },
       });
-    }
-    default:
-      throw new Error(`Unsupported event type: ${body.t}`);
   }
 }

--- a/src/core/key-event-log.ts
+++ b/src/core/key-event-log.ts
@@ -267,7 +267,7 @@ function verifyDelegationAnchor(
   // format relies on the verifier deriving the anchor from the delegator's
   // KEL directly when the couple isn't transmitted.
   const matchingSeal = (event: KeyEvent) => {
-    const anchors = event.body.a as KeyEventSeal[];
+    const anchors = (event.body.a ?? []) as KeyEventSeal[];
     return anchors.some((seal) => seal.i === body.i && seal.s === body.s && seal.d === body.d);
   };
 

--- a/src/core/key-event-log.ts
+++ b/src/core/key-event-log.ts
@@ -114,8 +114,8 @@ export class KeyEventLog {
 
     const referencedAsDelegator = new Set<string>();
     for (const events of byAid.values()) {
-      const dip = events.find((e) => e.body.t === "dip");
-      if (dip && dip.body.t === "dip") {
+      const dip = events.find((e): e is Message<DipEventBody> => e.body.t === "dip");
+      if (dip) {
         referencedAsDelegator.add(dip.body.di);
       }
     }
@@ -226,15 +226,15 @@ export class KeyEventLog {
         }
         break;
       }
+      default: {
+        const _exhaustive: never = body;
+        throw new Error(`Unsupported event type: ${(_exhaustive as { t: string }).t}`);
+      }
     }
 
     const newState = reduceKeyState(this.#state, body);
     return new KeyEventLog([...this.#events, message], newState, delegator ?? null);
   }
-}
-
-export function isKelEventType(t: unknown): boolean {
-  return t === "icp" || t === "ixn" || t === "rot" || t === "dip" || t === "drt";
 }
 
 interface KeyEventSeal {
@@ -267,7 +267,7 @@ function verifyDelegationAnchor(
   // format relies on the verifier deriving the anchor from the delegator's
   // KEL directly when the couple isn't transmitted.
   const matchingSeal = (event: KeyEvent) => {
-    const anchors = (event.body.a ?? []) as KeyEventSeal[];
+    const anchors = event.body.a as KeyEventSeal[];
     return anchors.some((seal) => seal.i === body.i && seal.s === body.s && seal.d === body.d);
   };
 
@@ -359,5 +359,9 @@ function reduceKeyState(state: KeyState | null, body: KeyEventBody): KeyState {
         lastEvent: { i: body.i, s: body.s, d: body.d },
         lastEstablishment: { i: body.i, s: body.s, d: body.d },
       });
+    default: {
+      const _exhaustive: never = body;
+      throw new Error(`Unsupported event type: ${(_exhaustive as { t: string }).t}`);
+    }
   }
 }

--- a/src/core/key-event.test.ts
+++ b/src/core/key-event.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { basename } from "node:path";
 import { describe, test } from "node:test";
 import { Message } from "../cesr/main.ts";
-import { delegatedIncept, delegatedRotate, incept, interact, type KeyEvent, rotate } from "./key-event.ts";
+import { delegatedIncept, delegatedRotate, incept, interact, isKeyEvent, type KeyEvent, rotate } from "./key-event.ts";
 import { KeyEventLog } from "./key-event-log.ts";
 import { generateKeyPair, type KeyPair } from "./keys.ts";
 import { sign as _sign } from "./sign.ts";
@@ -391,6 +391,52 @@ describe(basename(import.meta.url), () => {
         delegator,
       });
       assert.equal(event.body.d, event.body.i);
+    });
+  });
+
+  describe("isKeyEvent", () => {
+    const delegator = "EAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    test("should return true for icp", () => {
+      const key = generateKeyPair({ seed: "k0" });
+      assert.equal(isKeyEvent(incept({ signingKeys: [key.publicKey], nextKeys: [] })), true);
+    });
+
+    test("should return true for ixn, rot, dip, drt", () => {
+      const key0 = generateKeyPair({ seed: "k0" });
+      const key1 = generateKeyPair({ seed: "k1" });
+      const key2 = generateKeyPair({ seed: "k2" });
+      const log = inceptLog(key0, key1);
+
+      const ixn = interact(log.state);
+      assert.equal(isKeyEvent(ixn), true);
+
+      const rot = rotate(log.state, { signingKeys: [key1.publicKey], nextKeyDigests: [key2.publicKeyDigest] });
+      assert.equal(isKeyEvent(rot), true);
+
+      const dip = delegatedIncept({
+        signingKeys: [key0.publicKey],
+        nextKeys: [key1.publicKeyDigest],
+        delegator,
+      });
+      assert.equal(isKeyEvent(dip), true);
+
+      const dipEvent = new Message(dip.body, { ControllerIdxSigs: sign(dip, [key0]) });
+      const dipLog = KeyEventLog.empty().append(dipEvent);
+      const drt = delegatedRotate(dipLog.state, {
+        signingKeys: [key1.publicKey],
+        nextKeyDigests: [key2.publicKeyDigest],
+      });
+      assert.equal(isKeyEvent(drt), true);
+    });
+
+    test("should return false for non-KEL message types", () => {
+      const stub = (t: string) => new Message({ v: "KERI10JSON000000_", t, d: "", i: "" } as never);
+      assert.equal(isKeyEvent(stub("rct")), false);
+      assert.equal(isKeyEvent(stub("rpy")), false);
+      assert.equal(isKeyEvent(stub("qry")), false);
+      assert.equal(isKeyEvent(stub("exn")), false);
+      assert.equal(isKeyEvent(stub("vcp")), false);
     });
   });
 

--- a/src/core/key-event.ts
+++ b/src/core/key-event.ts
@@ -113,16 +113,18 @@ function isTransferable(key: string) {
   }
 }
 
-export type KeyEventBody = {
-  v: string;
-  t: string;
-  d: string;
-  i: string;
-  s: string;
-  [key: string]: unknown;
-};
+export type KeyEventBody = InceptEventBody | RotateEventBody | InteractEventBody | DipEventBody | DrtEventBody;
 
 export type KeyEvent<T extends KeyEventBody = KeyEventBody> = Message<T>;
+
+// Shallow type guard: matches on `t` only. Does not verify structural validity
+// of the rest of the body (required fields, SAID, etc.) — those checks happen
+// later in `KeyEventLog.append` or in a parser layer. Use this at the boundary
+// between untyped `Message` and typed `KeyEvent` to drop redundant casts.
+export function isKeyEvent(m: Message): m is KeyEvent {
+  const t = m.body.t;
+  return t === "icp" || t === "rot" || t === "ixn" || t === "dip" || t === "drt";
+}
 
 export function incept(args: InceptArgs): KeyEvent<InceptEventBody> {
   const keys = args.signingKeys;

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -59,15 +59,22 @@ export type {
   RotateArgs,
   RotateEventBody,
 } from "./key-event.ts";
-export { delegatedIncept, delegatedRotate } from "./key-event.ts";
+export { delegatedIncept, delegatedRotate, isKeyEvent } from "./key-event.ts";
 export { isKelEventType, KeyEventLog } from "./key-event-log.ts";
 export type { GenerateKeyPairOptions, KeyPair } from "./keys.ts";
 export { generateKeyPair } from "./keys.ts";
 
 export type { MailboxClientOptions } from "./mailbox-client.ts";
 export { MailboxClient } from "./mailbox-client.ts";
-export type { ReceiptEventBody, ReceiptEventInit } from "./receipt-event.ts";
-export type { RegistryInceptEventBody, RegistryInceptEventInit } from "./registry-event.ts";
+export type { ReceiptEvent, ReceiptEventBody, ReceiptEventInit } from "./receipt-event.ts";
+export { isReceipt } from "./receipt-event.ts";
+export type {
+  RegistryEvent,
+  RegistryEventBody,
+  RegistryInceptEventBody,
+  RegistryInceptEventInit,
+} from "./registry-event.ts";
+export { isRegistryInception } from "./registry-event.ts";
 export type {
   ExchangeEventBody,
   ExchangeEventInit,
@@ -75,7 +82,10 @@ export type {
   QueryEventInit,
   ReplyEventBody,
   ReplyEventInit,
+  RoutedEvent,
+  RoutedEventBody,
 } from "./routed-event.ts";
+export { isExchange, isQuery, isReply, isRoutedEvent } from "./routed-event.ts";
 export type { SignOptions } from "./sign.ts";
 export { sign } from "./sign.ts";
 export type { Threshold } from "./threshold.ts";

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -60,7 +60,7 @@ export type {
   RotateEventBody,
 } from "./key-event.ts";
 export { delegatedIncept, delegatedRotate, isKeyEvent } from "./key-event.ts";
-export { isKelEventType, KeyEventLog } from "./key-event-log.ts";
+export { KeyEventLog } from "./key-event-log.ts";
 export type { GenerateKeyPairOptions, KeyPair } from "./keys.ts";
 export { generateKeyPair } from "./keys.ts";
 

--- a/src/core/receipt-event.test.ts
+++ b/src/core/receipt-event.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import { Message } from "../cesr/main.ts";
+import { isReceipt, receipt } from "./receipt-event.ts";
+
+describe(basename(import.meta.url), () => {
+  describe("isReceipt", () => {
+    test("should return true for rct produced by receipt()", () => {
+      const m = receipt({ d: "EAAAAAAA", i: "EBBBBBBB", s: "0" });
+      assert.equal(isReceipt(m), true);
+    });
+
+    test("should return false for non-rct message types", () => {
+      const stub = (t: string) => new Message({ v: "KERI10JSON000000_", t, d: "", i: "" } as never);
+      assert.equal(isReceipt(stub("icp")), false);
+      assert.equal(isReceipt(stub("rpy")), false);
+      assert.equal(isReceipt(stub("exn")), false);
+    });
+  });
+});

--- a/src/core/receipt-event.ts
+++ b/src/core/receipt-event.ts
@@ -18,6 +18,10 @@ export type ReceiptEventBody = {
 
 export type ReceiptEvent = Message<ReceiptEventBody>;
 
+export function isReceipt(m: Message): m is ReceiptEvent {
+  return m.body.t === "rct";
+}
+
 export function receipt(args: ReceiptEventInit): ReceiptEvent {
   const body = encodeEvent<ReceiptEventBody>(
     {

--- a/src/core/registry-event.test.ts
+++ b/src/core/registry-event.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { basename } from "node:path";
 import { describe, test } from "node:test";
-import { Matter } from "../cesr/main.ts";
-import { incept } from "./registry-event.ts";
+import { Matter, Message } from "../cesr/main.ts";
+import { incept, isRegistryInception } from "./registry-event.ts";
 
 describe(basename(import.meta.url), () => {
   test("should create registry incept event", () => {
@@ -37,5 +37,19 @@ describe(basename(import.meta.url), () => {
     const salt = Matter.parse(event.body.n);
 
     assert.strictEqual(salt.code, Matter.Code.Salt_128);
+  });
+
+  describe("isRegistryInception", () => {
+    test("should return true for vcp produced by incept()", () => {
+      const event = incept({ ii: "EGpWO66krJQ5KqdGbB35e_V_vF0BfHR8APf__IkZEkI3" });
+      assert.equal(isRegistryInception(event), true);
+    });
+
+    test("should return false for non-vcp message types", () => {
+      const stub = (t: string) => new Message({ v: "KERI10JSON000000_", t, d: "", i: "" } as never);
+      assert.equal(isRegistryInception(stub("icp")), false);
+      assert.equal(isRegistryInception(stub("rct")), false);
+      assert.equal(isRegistryInception(stub("iss")), false);
+    });
   });
 });

--- a/src/core/registry-event.ts
+++ b/src/core/registry-event.ts
@@ -19,15 +19,13 @@ export type RegistryInceptEventBody = {
   n: string;
 };
 
-export type RegistryEventBody = {
-  v: string;
-  t: string;
-  d: string;
-  i: string;
-  [key: string]: unknown;
-};
+export type RegistryEventBody = RegistryInceptEventBody;
 
 export type RegistryEvent = Message<RegistryEventBody>;
+
+export function isRegistryInception(m: Message): m is Message<RegistryInceptEventBody> {
+  return m.body.t === "vcp";
+}
 
 export function incept(args: RegistryInceptEventInit): Message<RegistryInceptEventBody> {
   const body = encodeEvent<RegistryInceptEventBody>(

--- a/src/core/routed-event.test.ts
+++ b/src/core/routed-event.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
 import { basename } from "node:path";
 import { describe, test } from "node:test";
-import { encodeText, Indexer } from "../cesr/main.ts";
+import { encodeText, Indexer, Message } from "../cesr/main.ts";
 import { formatDate } from "./events.ts";
-import { exchange } from "./routed-event.ts";
+import { exchange, isExchange, isQuery, isReply, isRoutedEvent, query, reply } from "./routed-event.ts";
 
 describe(basename(import.meta.url), () => {
   test("should create exchange event", () => {
@@ -77,5 +77,42 @@ describe(basename(import.meta.url), () => {
     const resultAttachments = event.attachments.PathedMaterialCouples[0];
     assert.partialDeepStrictEqual(resultAttachments, { path: "-e-foo", grouped: true });
     assert.deepStrictEqual(resultAttachments.attachments.ControllerIdxSigs, sigs);
+  });
+
+  describe("type guards", () => {
+    const sender = "EFAWQA1ktXrt5BFptVJrx6zKT8n6UIqU1XDP0tSB6yUS";
+    const qry = query({ q: {}, r: "mbx" });
+    const rpy = reply({ r: "/loc/scheme", a: {} });
+    const exn = exchange({ sender, route: "/fwd" });
+    const stub = (t: string) => new Message({ v: "KERI10JSON000000_", t, d: "", i: "" } as never);
+
+    test("isQuery should narrow to qry only", () => {
+      assert.equal(isQuery(qry), true);
+      assert.equal(isQuery(rpy), false);
+      assert.equal(isQuery(exn), false);
+      assert.equal(isQuery(stub("icp")), false);
+    });
+
+    test("isReply should narrow to rpy only", () => {
+      assert.equal(isReply(rpy), true);
+      assert.equal(isReply(qry), false);
+      assert.equal(isReply(exn), false);
+      assert.equal(isReply(stub("rct")), false);
+    });
+
+    test("isExchange should narrow to exn only", () => {
+      assert.equal(isExchange(exn), true);
+      assert.equal(isExchange(qry), false);
+      assert.equal(isExchange(rpy), false);
+    });
+
+    test("isRoutedEvent should be true for qry/rpy/exn and false for others", () => {
+      assert.equal(isRoutedEvent(qry), true);
+      assert.equal(isRoutedEvent(rpy), true);
+      assert.equal(isRoutedEvent(exn), true);
+      assert.equal(isRoutedEvent(stub("icp")), false);
+      assert.equal(isRoutedEvent(stub("rct")), false);
+      assert.equal(isRoutedEvent(stub("vcp")), false);
+    });
   });
 });

--- a/src/core/routed-event.ts
+++ b/src/core/routed-event.ts
@@ -34,15 +34,27 @@ export type ReplyEventBody = {
   a: Record<string, unknown>;
 };
 
-export type RoutedEventBody = {
-  v: string;
-  t: string;
-  d: string;
-  r: string;
-  [key: string]: unknown;
-};
+export type RoutedEventBody = QueryEventBody | ReplyEventBody | ExchangeEventBody;
 
 export type RoutedEvent = Message<RoutedEventBody>;
+
+// Shallow type guards: match on `t` only. Structural validation (required
+// fields, SAID, signature verification against signer's KEL) happens later.
+export function isQuery(m: Message): m is Message<QueryEventBody> {
+  return m.body.t === "qry";
+}
+
+export function isReply(m: Message): m is Message<ReplyEventBody> {
+  return m.body.t === "rpy";
+}
+
+export function isExchange(m: Message): m is Message<ExchangeEventBody> {
+  return m.body.t === "exn";
+}
+
+export function isRoutedEvent(m: Message): m is RoutedEvent {
+  return isQuery(m) || isReply(m) || isExchange(m);
+}
 
 export function query(args: QueryEventInit): Message<QueryEventBody> {
   const body = encodeEvent<QueryEventBody>({

--- a/src/core/witness-client.test.ts
+++ b/src/core/witness-client.test.ts
@@ -5,6 +5,7 @@ import { encodeText, Message } from "../cesr/main.ts";
 import { incept, type KeyEvent } from "./key-event.ts";
 import { generateKeyPair, type KeyPair } from "./keys.ts";
 import { receipt } from "./receipt-event.ts";
+import { reply } from "./routed-event.ts";
 import { sign } from "./sign.ts";
 import { WitnessClient } from "./witness-client.ts";
 
@@ -83,6 +84,19 @@ describe(basename(import.meta.url), () => {
 
       const client = new WitnessClient("ftp://witness.example", async () => new Response(""));
       await assert.rejects(() => client.receipt(event), /Invalid protocol/);
+    });
+
+    test("should pick the rct out of a mixed-message response stream", async () => {
+      const { event, witnessKey } = makeEvent();
+      const rpyMsg = reply({ r: "/loc/scheme", a: { foo: "bar" } });
+      const rpyBody = JSON.stringify(rpyMsg.body) + encodeText(rpyMsg.attachments.frames());
+      const rctBody = makeReceiptResponse(event, witnessKey);
+
+      const client = new WitnessClient("http://witness.example", async () => new Response(rpyBody + rctBody));
+      const rct = await client.receipt(event);
+
+      assert.strictEqual(rct.body.t, "rct");
+      assert.strictEqual(rct.body.d, event.body.d);
     });
   });
 });

--- a/src/core/witness-client.ts
+++ b/src/core/witness-client.ts
@@ -1,6 +1,6 @@
 import { encodeText, Matter, type Message, parse } from "../cesr/main.ts";
 import type { KeyEventBody } from "./key-event.ts";
-import type { ReceiptEvent } from "./receipt-event.ts";
+import { isReceipt, type ReceiptEvent } from "./receipt-event.ts";
 import { verifySignature } from "./verify.ts";
 
 export class WitnessClient {
@@ -33,14 +33,14 @@ export class WitnessClient {
     }
 
     for await (const incoming of parse(fetchResponse.body)) {
-      if (incoming.body.t === "rct" && incoming.body.d === event.body.d) {
+      if (isReceipt(incoming) && incoming.body.d === event.body.d) {
         for (const couple of incoming.attachments.NonTransReceiptCouples) {
           if (!verifySignature(event.raw, Matter.parse(couple.prefix), Matter.parse(couple.sig).raw)) {
             throw new Error(`Invalid witness signature from ${couple.prefix}`);
           }
         }
 
-        return incoming as ReceiptEvent;
+        return incoming;
       }
     }
 

--- a/src/mailbox/mailbox.ts
+++ b/src/mailbox/mailbox.ts
@@ -1,7 +1,7 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { encodeText, Indexer, Matter, Message, type MessageBody } from "../cesr/main.ts";
 import type { ExchangeEventBody, QueryEventBody } from "../core/main.ts";
-import { KeyEventLog, keri } from "../core/main.ts";
+import { isExchange, isQuery, KeyEventLog, keri } from "../core/main.ts";
 import { KeriLogger, type Logger } from "../logging/main.ts";
 import type { MailboxServerStorage } from "../storage/main.ts";
 
@@ -81,21 +81,19 @@ export class Mailbox {
   }
 
   async *handleMessage(message: Message): AsyncGenerator<MailboxReply> {
-    const { t, r } = message.body as { t?: string; r?: string };
-
-    if (t === "exn" && r === "/fwd") {
+    if (isExchange(message) && message.body.r === "/fwd") {
       this.#log.debug("handling exn /fwd");
-      this.#handleForward(message as Message<ExchangeEventBody>);
+      this.#handleForward(message);
       return;
     }
 
-    if (t === "qry" && r === "mbx") {
+    if (isQuery(message) && message.body.r === "mbx") {
       this.#log.debug("handling qry mbx");
-      yield* this.#handleQuery(message as Message<QueryEventBody>);
+      yield* this.#handleQuery(message);
       return;
     }
 
-    this.#log.debug("ignoring message", { t, r });
+    this.#log.debug("ignoring message", { t: message.body.t });
   }
 
   #handleForward(message: Message<ExchangeEventBody>): void {

--- a/src/witness/witness-router.test.ts
+++ b/src/witness/witness-router.test.ts
@@ -211,6 +211,25 @@ describe(basename(import.meta.url), () => {
       assert(ed25519.verify(sigMatter.raw, context.icp.raw, keyMatter.raw));
     });
 
+    test("should return 400 when POSTed body is not a key event", async () => {
+      const context = new TestContext();
+      const rpy = keri.reply({ r: "/loc/scheme", a: { eid: "EFAKE", scheme: "http", url: "http://example" } });
+      const atc = new Attachments({});
+
+      const response = await context.fetch(
+        request("/receipts", {
+          method: "POST",
+          body: new TextDecoder().decode(rpy.raw),
+          headers: {
+            "Content-Type": "application/json",
+            "CESR-ATTACHMENT": encodeText(atc.frames()),
+          },
+        }),
+      );
+
+      assert.strictEqual(response.status, 400);
+    });
+
     test("should respond on oobi request for the new identifier", async () => {
       const context = new TestContext();
       await context.receipt(context.icp, context.sigs);

--- a/src/witness/witness-router.test.ts
+++ b/src/witness/witness-router.test.ts
@@ -4,7 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, test } from "node:test";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { Attachments, encodeText, Indexer, Matter, type Message, parse } from "../cesr/main.ts";
-import { generateKeyPair, type InceptEventBody, type KeyEvent, keri } from "../core/main.ts";
+import { generateKeyPair, type InceptEventBody, type KeyEvent, KeyEventLog, keri } from "../core/main.ts";
 import { NodeSqliteDatabase, SqliteControllerStorage } from "../sqlite-storage/main.ts";
 import { Witness } from "./witness.ts";
 import { createRouter } from "./witness-router.ts";
@@ -209,6 +209,33 @@ describe(basename(import.meta.url), () => {
       const sigMatter = Matter.parse(couple.sig);
       const keyMatter = Matter.parse(couple.prefix);
       assert(ed25519.verify(sigMatter.raw, context.icp.raw, keyMatter.raw));
+    });
+
+    test("should report the receipted event's sequence number in FirstSeenReplayCouples", async () => {
+      const context = new TestContext();
+      await context.receipt(context.icp, context.sigs);
+
+      // Receipt a non-inception event (ixn at s=1) — fnu must reflect its real
+      // sequence number, not a hardcoded "0".
+      const state = KeyEventLog.from(context.witness.getKeyEvents(context.icp.body.i)).state;
+      const ixn = keri.interact(state);
+      const ixnSig = encodeText(Indexer.crypto.ed25519_sig(ed25519.sign(ixn.raw, privateKey0), 0));
+
+      const response = await context.fetch(
+        request("/receipts", {
+          method: "POST",
+          body: new TextDecoder().decode(ixn.raw),
+          headers: {
+            "Content-Type": "application/json",
+            "CESR-ATTACHMENT": encodeText(new Attachments({ ControllerIdxSigs: [ixnSig] }).frames()),
+          },
+        }),
+      );
+
+      const messages = await collect(response.body);
+      assert.strictEqual(messages[0].body.t, "rct");
+      assert.strictEqual(messages[0].body.s, "1");
+      assert.strictEqual(messages[0].attachments.FirstSeenReplayCouples[0].fnu, "1");
     });
 
     test("should return 400 when POSTed body is not a key event", async () => {

--- a/src/witness/witness-router.ts
+++ b/src/witness/witness-router.ts
@@ -10,7 +10,7 @@ export interface RouterOptions {
 function createResponse(events: readonly WitnessEvent[]): Response {
   const body = events
     .flatMap(({ message, timestamp }) => {
-      const sn = isKeyEvent(message) ? message.body.s : "0";
+      const sn = String((message.body as { s?: string }).s ?? "0");
       const atc = new Attachments({
         ControllerIdxSigs: message.attachments.ControllerIdxSigs,
         WitnessIdxSigs: message.attachments.WitnessIdxSigs,

--- a/src/witness/witness-router.ts
+++ b/src/witness/witness-router.ts
@@ -1,5 +1,5 @@
 import { Attachments, encodeText, parse } from "../cesr/main.ts";
-import type { KeyEvent, KeyEventBody } from "../core/main.ts";
+import { isKeyEvent } from "../core/main.ts";
 import { KeriLogger, type Logger } from "../logging/main.ts";
 import { type Witness, WitnessError, type WitnessEvent } from "./witness.ts";
 
@@ -10,11 +10,12 @@ export interface RouterOptions {
 function createResponse(events: readonly WitnessEvent[]): Response {
   const body = events
     .flatMap(({ message, timestamp }) => {
+      const sn = isKeyEvent(message) ? message.body.s : "0";
       const atc = new Attachments({
         ControllerIdxSigs: message.attachments.ControllerIdxSigs,
         WitnessIdxSigs: message.attachments.WitnessIdxSigs,
         NonTransReceiptCouples: message.attachments.NonTransReceiptCouples,
-        FirstSeenReplayCouples: [{ fnu: String((message.body as KeyEventBody).s ?? "0"), dt: timestamp }],
+        FirstSeenReplayCouples: [{ fnu: sn, dt: timestamp }],
       });
       return [new TextDecoder().decode(message.raw), encodeText(atc.frames())];
     })
@@ -40,8 +41,12 @@ export function createRouter(witness: Witness, options: RouterOptions = {}): (re
     const receipts: WitnessEvent[] = [];
 
     for await (const witnessEvent of parse(bodyText + atc)) {
+      if (!isKeyEvent(witnessEvent)) {
+        log.warn("rejecting POST /receipts: not a key event", { t: witnessEvent.body.t });
+        return Response.json({ error: "Bad Request" }, { status: 400 });
+      }
       try {
-        const receipt = witness.receipt(witnessEvent as KeyEvent);
+        const receipt = witness.receipt(witnessEvent);
         receipts.push({ message: receipt, timestamp: new Date() });
       } catch (err) {
         if (err instanceof WitnessError) {

--- a/src/witness/witness.test.ts
+++ b/src/witness/witness.test.ts
@@ -176,6 +176,17 @@ describe(basename(import.meta.url), () => {
       assert.strictEqual(saveSpy.mock.callCount(), 0);
     });
 
+    test("should be a no-op for a malformed rct missing i/d", () => {
+      const witness = makeWitness();
+      // `i` omitted: without the presence guard this reaches getKeyEvents(undefined),
+      // which node:sqlite rejects as an unsupported bind type.
+      const rctMsg = new Message({ v: "KERI10JSON000000_", t: "rct", d: "", s: "0" } as never, {
+        NonTransReceiptCouples: [],
+      });
+
+      assert.doesNotThrow(() => witness.handleMessage(rctMsg));
+    });
+
     test("should merge NonTransReceiptCouples from another witness", () => {
       const witness = makeWitness();
       const { privateKey: otherKey, publicKey: otherPub } = generateKeyPair({

--- a/src/witness/witness.ts
+++ b/src/witness/witness.ts
@@ -1,6 +1,6 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { Attachments, encodeText, Indexer, Matter, Message } from "../cesr/main.ts";
-import { type KeyEvent, type KeyEventBody, KeyEventLog, keri, type ReceiptEventBody } from "../core/main.ts";
+import { isReceipt, type KeyEvent, type KeyEventBody, KeyEventLog, keri, type ReceiptEventBody } from "../core/main.ts";
 import { KeriLogger, type Logger } from "../logging/main.ts";
 import type { KeyEventStorage } from "../storage/main.ts";
 
@@ -146,17 +146,12 @@ export class Witness {
   }
 
   handleMessage(message: Message): void {
-    const body = message.body as KeyEventBody;
-
-    if (body.t !== "rct") {
-      this.#log.debug("ignoring message: only rct handled", { t: body.t });
+    if (!isReceipt(message)) {
+      this.#log.debug("ignoring message: only rct handled", { t: message.body.t });
       return;
     }
 
-    if (typeof body.i !== "string" || typeof body.d !== "string") {
-      this.#log.warn("ignoring receipt: missing i/d");
-      return;
-    }
+    const body = message.body;
 
     const kel = KeyEventLog.from(this.#storage.getKeyEvents(body.i), {
       // TODO: This should only be for the event that is this receit

--- a/src/witness/witness.ts
+++ b/src/witness/witness.ts
@@ -153,6 +153,11 @@ export class Witness {
 
     const body = message.body;
 
+    if (typeof body.i !== "string" || typeof body.d !== "string") {
+      this.#log.warn("ignoring receipt: missing i/d");
+      return;
+    }
+
     const kel = KeyEventLog.from(this.#storage.getKeyEvents(body.i), {
       // TODO: This should only be for the event that is this receit
       allowPartiallyWitnessed: true,


### PR DESCRIPTION
## Summary

- Convert `KeyEventBody`, `RoutedEventBody`, `RegistryEventBody` from open shapes (`t: string` + index signature) into proper discriminated unions over their concrete body types.
- Add shallow `is*` type guards (`isKeyEvent`, `isQuery`, `isReply`, `isExchange`, `isRoutedEvent`, `isReceipt`, `isRegistryInception`) for use at parse/storage boundaries.
- Drop ~20 redundant `as XEventBody` casts across `key-event-log.ts`, `controller.ts`, `witness.ts`, `witness-router.ts`, `mailbox.ts`, `witness-client.ts` — TS now narrows on `body.t` inside switch arms.

## Why

The casts existed because `KeyEventBody`'s open shape (`t: string`, `[key: string]: unknown`) prevented TS from narrowing on `body.t`. Replacing it with a discriminated union of the five concrete body types fixes that at the root.

The guards are intentionally shallow — they only check the discriminant. Deeper structural validation (required fields, SAID re-derivation) is a follow-up belonging to a parser layer between CESR and the consumers.

This also sets up multi-version (v1/v2) work: when v2 lands with reshaped types like `exn`, the existing union becomes e.g. `RoutedEventBodyV1 | RoutedEventBodyV2` without renaming today's symbols.

## Out of scope

- Per-type structural validators / SAID at parse — needs a centralized event parser.
- `KelResolver` abstraction for routed-event signature verification — separate piece.
- Two `as unknown as KeyEventBody` casts in `sqlite-storage/main.ts` — those sit inside `prepareRow`'s generic-over-`T` context and need the parser-layer boundary to remove cleanly.
- `isKelEventType` left exported alongside `isKeyEvent` for back-compat; can be deprecated in a follow-up.

## Test plan

- [x] `npm run check` — typecheck clean
- [x] `npm run lint` (via `npx biome check src/`) — clean
- [x] `npm run test` — 484/484 pass