### PR TITLE
feat: offline ACDC verifier and sample verifier app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Type check
         run: npm run check
 
+      - name: Type check verifier app
+        run: npm run check:verifier
+
       - name: Run build
         run: npm run build
 
@@ -92,8 +95,9 @@ jobs:
         run: deno install --frozen
  
       - name: Deno typecheck
-        run: deno check --conditions=keri-source src
+        run: deno check src
+
 
       - name: Run test in deno
-        run: deno test --allow-net --allow-read --conditions=keri-source
+        run: deno test --allow-net --allow-read src test_vectors
 

--- a/apps/verifier/index.html
+++ b/apps/verifier/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ACDC Verifier</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/verifier/src/App.tsx
+++ b/apps/verifier/src/App.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useState } from "react";
+import type { CredentialVerification } from "../../../src/core/main.ts";
+import { EventIndex, verifyCredentials } from "../../../src/core/main.ts";
+import { CredentialResult } from "./CredentialResult.tsx";
+
+type State =
+  | { kind: "idle" }
+  | { kind: "error"; message: string }
+  | { kind: "done"; results: CredentialVerification[] };
+
+export function App() {
+  const [state, setState] = useState<State>({ kind: "idle" });
+  const [dragging, setDragging] = useState(false);
+
+  const verify = useCallback(async (input: Uint8Array | string) => {
+    try {
+      setState({ kind: "done", results: verifyCredentials(await EventIndex.parse(input)) });
+    } catch (error) {
+      setState({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  }, []);
+
+  const onDrop = useCallback(
+    async (event: React.DragEvent) => {
+      event.preventDefault();
+      setDragging(false);
+      const file = event.dataTransfer.files[0];
+      if (file) {
+        await verify(new Uint8Array(await file.arrayBuffer()));
+      }
+    },
+    [verify],
+  );
+
+  return (
+    <main>
+      <h1>ACDC Verifier</h1>
+      <p className="lede">
+        Drop a CESR stream containing a credential, its issuer's key event log, and the registry events. Everything is
+        verified in this page — no network, no server.
+      </p>
+
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: drag and drop enhances the file input below, which stays the accessible path */}
+      <section
+        className={`dropzone${dragging ? " dragging" : ""}`}
+        onDrop={onDrop}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+      >
+        <p>Drop a .cesr file here</p>
+        <label className="file">
+          or choose a file
+          <input
+            type="file"
+            onChange={async (event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                await verify(new Uint8Array(await file.arrayBuffer()));
+              }
+            }}
+          />
+        </label>
+      </section>
+
+      <details className="paste">
+        <summary>Paste a stream instead</summary>
+        {/* Verification is synchronous and costs ~13ms per credential, so it runs on
+            commit rather than on every keystroke. */}
+        <textarea
+          rows={6}
+          placeholder='{"v":"KERI10JSON…'
+          onBlur={(event) => {
+            const text = event.target.value.trim();
+            if (text) {
+              void verify(text);
+            }
+          }}
+        />
+      </details>
+
+      {state.kind === "error" && <p className="error">Could not read the stream: {state.message}</p>}
+
+      {state.kind === "done" && state.results.length === 0 && (
+        <p className="error">No credential found in that stream.</p>
+      )}
+
+      {state.kind === "done" && state.results.map((result) => <CredentialResult key={result.said} result={result} />)}
+    </main>
+  );
+}

--- a/apps/verifier/src/CredentialResult.tsx
+++ b/apps/verifier/src/CredentialResult.tsx
@@ -1,0 +1,87 @@
+import type { CredentialVerification } from "../../../src/core/main.ts";
+import { disclosedAttributes } from "../../../src/core/main.ts";
+import { CHECK_LABELS, STATUS_MARKS } from "./checks.ts";
+
+function Claims({ result }: { result: CredentialVerification }) {
+  const claims = disclosedAttributes(result.credential.body);
+  if (claims.length === 0) {
+    return null;
+  }
+
+  return (
+    <dl className="claims">
+      {claims.map(([key, value]) => (
+        <div key={key}>
+          <dt>{key}</dt>
+          <dd>{typeof value === "object" ? JSON.stringify(value) : String(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function CredentialResult({ result }: { result: CredentialVerification }) {
+  return (
+    <article className="result">
+      <header className={`verdict verdict-${result.ok ? "ok" : "bad"}`}>
+        <strong>{result.ok ? "Verified" : "Not verified"}</strong>
+        <span className={`status status-${result.status}`}>{result.status}</span>
+      </header>
+
+      <Claims result={result} />
+
+      <dl className="identifiers">
+        <div>
+          <dt>Credential</dt>
+          <dd>{result.said}</dd>
+        </div>
+        <div>
+          <dt>Issuer</dt>
+          <dd>{result.issuer}</dd>
+        </div>
+        {result.issuee && (
+          <div>
+            <dt>Issued to</dt>
+            <dd>{result.issuee}</dd>
+          </div>
+        )}
+        <div>
+          <dt>Registry</dt>
+          <dd>{result.registry}</dd>
+        </div>
+        <div>
+          <dt>Schema</dt>
+          <dd>{result.schema}</dd>
+        </div>
+        {result.issuedAt && (
+          <div>
+            <dt>Issued</dt>
+            <dd>{result.issuedAt}</dd>
+          </div>
+        )}
+        {result.revokedAt && (
+          <div>
+            <dt>Revoked</dt>
+            <dd>{result.revokedAt}</dd>
+          </div>
+        )}
+        {result.edges.map((edge) => (
+          <div key={edge.label}>
+            <dt>{`↳ ${edge.label}`}</dt>
+            <dd className={edge.ok ? "edge-ok" : "edge-bad"}>{edge.said}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <ul className="checks">
+        {result.checks.map((check) => (
+          <li key={check.id} className={`check check-${check.status}`}>
+            <span className="mark">{STATUS_MARKS[check.status]}</span>
+            <span className="label">{CHECK_LABELS[check.id]}</span>
+            {check.detail && <span className="detail">{check.detail}</span>}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/apps/verifier/src/checks.ts
+++ b/apps/verifier/src/checks.ts
@@ -1,0 +1,22 @@
+import type { CheckStatus, CredentialCheckId } from "../../../src/core/main.ts";
+
+export const CHECK_LABELS: Record<CredentialCheckId, string> = {
+  "acdc-said": "Credential SAID",
+  "acdc-section-saids": "Section SAIDs",
+  "issuer-kel": "Issuer key event log",
+  "registry-inception": "Registry inception",
+  "registry-anchor": "Registry anchored in issuer KEL",
+  issuance: "Issuance event",
+  "issuance-anchor": "Issuance anchored in issuer KEL",
+  "revocation-anchor": "Revocation",
+  edges: "Linked credentials",
+  schema: "Schema",
+};
+
+export const STATUS_MARKS: Record<CheckStatus, string> = {
+  passed: "✓",
+  failed: "✗",
+  skipped: "–",
+  "not-applicable": "–",
+  unchecked: "?",
+};

--- a/apps/verifier/src/main.tsx
+++ b/apps/verifier/src/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Missing #root element");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/verifier/src/styles.css
+++ b/apps/verifier/src/styles.css
@@ -1,0 +1,242 @@
+:root {
+  --bg: #12141a;
+  --panel: #1a1d26;
+  --border: #2a2f3d;
+  --text: #e6e8ee;
+  --muted: #8b93a7;
+  --ok: #3fb950;
+  --bad: #f85149;
+  --warn: #d29922;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font:
+    15px / 1.5 ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+main {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.6rem;
+}
+
+.lede {
+  margin: 0 0 2rem;
+  color: var(--muted);
+  max-width: 40rem;
+}
+
+.dropzone {
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.dropzone.dragging {
+  border-color: var(--ok);
+  background: #16241a;
+}
+
+.dropzone p {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+}
+
+.file {
+  cursor: pointer;
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.file input {
+  display: none;
+}
+
+.paste {
+  margin-top: 1rem;
+  color: var(--muted);
+}
+
+.paste textarea {
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  resize: vertical;
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--bad);
+  border-radius: 8px;
+  color: var(--bad);
+}
+
+.result {
+  margin-top: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  overflow: hidden;
+}
+
+.verdict {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.1rem;
+}
+
+.verdict-ok strong {
+  color: var(--ok);
+}
+
+.verdict-bad strong {
+  color: var(--bad);
+}
+
+.status {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.status-issued {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.status-revoked {
+  color: var(--bad);
+  border-color: var(--bad);
+}
+
+.claims {
+  margin: 0;
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.claims div {
+  display: flex;
+  gap: 1rem;
+}
+
+.claims dt {
+  min-width: 8rem;
+  color: var(--muted);
+}
+
+.claims dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.identifiers {
+  margin: 0;
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 0.4rem;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+
+.identifiers div {
+  display: flex;
+  gap: 1rem;
+}
+
+.identifiers dt {
+  min-width: 6rem;
+  color: var(--muted);
+}
+
+.identifiers dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.edge-ok {
+  color: var(--ok);
+}
+
+.edge-bad {
+  color: var(--bad);
+}
+
+.checks {
+  margin: 0;
+  padding: 0.75rem 1.25rem 1.25rem;
+  list-style: none;
+}
+
+.check {
+  display: grid;
+  grid-template-columns: 1.5rem 1fr;
+  gap: 0.25rem 0.5rem;
+  padding: 0.4rem 0;
+}
+
+.check .mark {
+  color: var(--muted);
+  text-align: center;
+}
+
+.check-passed .mark {
+  color: var(--ok);
+}
+
+.check-failed .mark {
+  color: var(--bad);
+}
+
+.check-unchecked .mark {
+  color: var(--warn);
+}
+
+.check-skipped .label,
+.check-not-applicable .label,
+.check-unchecked .label {
+  color: var(--muted);
+}
+
+.check .detail {
+  grid-column: 2;
+  font-size: 12px;
+  color: var(--muted);
+}

--- a/apps/verifier/tsconfig.json
+++ b/apps/verifier/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "include": ["src", "vite.config.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "esnext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"]
+  }
+}

--- a/apps/verifier/vite.config.ts
+++ b/apps/verifier/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { fs: { allow: [".."] } },
+});

--- a/deno.lock
+++ b/deno.lock
@@ -8,11 +8,17 @@
     "npm:@noble/secp256k1@3": "3.1.0",
     "npm:@types/debug@^4.1.13": "4.1.13",
     "npm:@types/node@^22.15.30": "22.19.17",
+    "npm:@types/react-dom@^19.2.4": "19.2.4_@types+react@19.2.18",
+    "npm:@types/react@^19.2.18": "19.2.18",
+    "npm:@vitejs/plugin-react@^6.0.5": "6.0.5_vite@8.2.1__@types+node@22.19.17_@types+node@22.19.17",
     "npm:concurrently@^9.2.1": "9.2.1",
     "npm:debug@^4.4.3": "4.4.3",
+    "npm:react-dom@^19.2.8": "19.2.8_react@19.2.8",
+    "npm:react@^19.2.8": "19.2.8",
     "npm:serve@^14.2.5": "14.2.6",
     "npm:typedoc@~0.28.14": "0.28.19_typescript@6.0.2",
-    "npm:typescript@^6.0.2": "6.0.2"
+    "npm:typescript@^6.0.2": "6.0.2",
+    "npm:vite@^8.2.1": "8.2.1_@types+node@22.19.17"
   },
   "npm": {
     "@biomejs/biome@2.4.11": {
@@ -94,6 +100,82 @@
     "@noble/secp256k1@3.1.0": {
       "integrity": "sha512-+F7iS7tUMaNGXcc9X3PjmjvuQnXEuSjCRNzVVA2xAcKXgCaP0dHYz4SFyt4FKNHef7sOP//xihowcySSS7PK9g=="
     },
+    "@oxc-project/types@0.144.0": {
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg=="
+    },
+    "@rolldown/binding-android-arm64@1.2.4": {
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-arm64@1.2.4": {
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-x64@1.2.4": {
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-freebsd-x64@1.2.4": {
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-arm-gnueabihf@1.2.4": {
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@rolldown/binding-linux-arm64-gnu@1.2.4": {
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-arm64-musl@1.2.4": {
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-ppc64-gnu@1.2.4": {
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@rolldown/binding-linux-s390x-gnu@1.2.4": {
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@rolldown/binding-linux-x64-gnu@1.2.4": {
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-x64-musl@1.2.4": {
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-openharmony-arm64@1.2.4": {
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-win32-arm64-msvc@1.2.4": {
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-win32-x64-msvc@1.2.4": {
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/pluginutils@1.0.1": {
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="
+    },
     "@shikijs/engine-oniguruma@3.23.0": {
       "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "dependencies": [
@@ -144,8 +226,27 @@
         "undici-types"
       ]
     },
+    "@types/react-dom@19.2.4_@types+react@19.2.18": {
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dependencies": [
+        "@types/react"
+      ]
+    },
+    "@types/react@19.2.18": {
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dependencies": [
+        "csstype"
+      ]
+    },
     "@types/unist@3.0.3": {
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "@vitejs/plugin-react@6.0.5_vite@8.2.1__@types+node@22.19.17_@types+node@22.19.17": {
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dependencies": [
+        "@rolldown/pluginutils",
+        "vite"
+      ]
     },
     "@zeit/schemas@2.36.0": {
       "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg=="
@@ -318,6 +419,9 @@
         "which"
       ]
     },
+    "csstype@3.2.3": {
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
     "debug@2.6.9": {
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": [
@@ -332,6 +436,9 @@
     },
     "deep-extend@0.6.0": {
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "detect-libc@2.1.2": {
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "eastasianwidth@0.2.0": {
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
@@ -367,6 +474,20 @@
     },
     "fast-uri@3.1.0": {
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "fdir@6.5.0_picomatch@4.0.5": {
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dependencies": [
+        "picomatch"
+      ],
+      "optionalPeers": [
+        "picomatch"
+      ]
+    },
+    "fsevents@2.3.3": {
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
@@ -407,6 +528,80 @@
     },
     "json-schema-traverse@1.0.0": {
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "lightningcss-android-arm64@1.33.0": {
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-darwin-arm64@1.33.0": {
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-darwin-x64@1.33.0": {
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-freebsd-x64@1.33.0": {
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-arm-gnueabihf@1.33.0": {
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "lightningcss-linux-arm64-gnu@1.33.0": {
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-arm64-musl@1.33.0": {
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-x64-gnu@1.33.0": {
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-x64-musl@1.33.0": {
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-win32-arm64-msvc@1.33.0": {
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-win32-x64-msvc@1.33.0": {
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "lightningcss@1.33.0": {
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dependencies": [
+        "detect-libc"
+      ],
+      "optionalDependencies": [
+        "lightningcss-android-arm64",
+        "lightningcss-darwin-arm64",
+        "lightningcss-darwin-x64",
+        "lightningcss-freebsd-x64",
+        "lightningcss-linux-arm-gnueabihf",
+        "lightningcss-linux-arm64-gnu",
+        "lightningcss-linux-arm64-musl",
+        "lightningcss-linux-x64-gnu",
+        "lightningcss-linux-x64-musl",
+        "lightningcss-win32-arm64-msvc",
+        "lightningcss-win32-x64-msvc"
+      ]
     },
     "linkify-it@5.0.0": {
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
@@ -471,6 +666,10 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "nanoid@3.3.18": {
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "bin": true
+    },
     "negotiator@0.6.4": {
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="
     },
@@ -498,6 +697,20 @@
     "path-to-regexp@3.3.0": {
       "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="
     },
+    "picocolors@1.1.1": {
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "picomatch@4.0.5": {
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
+    },
+    "postcss@8.5.26": {
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dependencies": [
+        "nanoid",
+        "picocolors",
+        "source-map-js"
+      ]
+    },
     "punycode.js@2.3.1": {
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
@@ -513,6 +726,16 @@
         "strip-json-comments"
       ],
       "bin": true
+    },
+    "react-dom@19.2.8_react@19.2.8": {
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dependencies": [
+        "react",
+        "scheduler"
+      ]
+    },
+    "react@19.2.8": {
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
     },
     "registry-auth-token@3.3.2": {
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
@@ -533,6 +756,30 @@
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
+    "rolldown@1.2.4": {
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dependencies": [
+        "@oxc-project/types",
+        "@rolldown/pluginutils"
+      ],
+      "optionalDependencies": [
+        "@rolldown/binding-android-arm64",
+        "@rolldown/binding-darwin-arm64",
+        "@rolldown/binding-darwin-x64",
+        "@rolldown/binding-freebsd-x64",
+        "@rolldown/binding-linux-arm-gnueabihf",
+        "@rolldown/binding-linux-arm64-gnu",
+        "@rolldown/binding-linux-arm64-musl",
+        "@rolldown/binding-linux-ppc64-gnu",
+        "@rolldown/binding-linux-s390x-gnu",
+        "@rolldown/binding-linux-x64-gnu",
+        "@rolldown/binding-linux-x64-musl",
+        "@rolldown/binding-openharmony-arm64",
+        "@rolldown/binding-win32-arm64-msvc",
+        "@rolldown/binding-win32-x64-msvc"
+      ],
+      "bin": true
+    },
     "rxjs@7.8.2": {
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dependencies": [
@@ -541,6 +788,9 @@
     },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "scheduler@0.27.0": {
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "serve-handler@6.1.7": {
       "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
@@ -585,6 +835,9 @@
     },
     "signal-exit@3.0.7": {
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "source-map-js@1.2.1": {
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -632,6 +885,13 @@
         "has-flag"
       ]
     },
+    "tinyglobby@0.2.17": {
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dependencies": [
+        "fdir",
+        "picomatch"
+      ]
+    },
     "tree-kill@1.2.2": {
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": true
@@ -673,6 +933,24 @@
     },
     "vary@1.1.2": {
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "vite@8.2.1_@types+node@22.19.17": {
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dependencies": [
+        "@types/node",
+        "lightningcss",
+        "picomatch",
+        "postcss",
+        "rolldown",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
     },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
@@ -736,11 +1014,17 @@
         "npm:@noble/secp256k1@3",
         "npm:@types/debug@^4.1.13",
         "npm:@types/node@^22.15.30",
+        "npm:@types/react-dom@^19.2.4",
+        "npm:@types/react@^19.2.18",
+        "npm:@vitejs/plugin-react@^6.0.5",
         "npm:concurrently@^9.2.1",
         "npm:debug@^4.4.3",
+        "npm:react-dom@^19.2.8",
+        "npm:react@^19.2.8",
         "npm:serve@^14.2.5",
         "npm:typedoc@~0.28.14",
-        "npm:typescript@^6.0.2"
+        "npm:typescript@^6.0.2",
+        "npm:vite@^8.2.1"
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,17 @@
         "@biomejs/biome": "^2.4.9",
         "@types/debug": "^4.1.13",
         "@types/node": "^22.15.30",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
         "concurrently": "^9.2.1",
         "debug": "^4.4.3",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "serve": "^14.2.5",
         "typedoc": "^0.28.14",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=22"
@@ -262,6 +268,279 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -348,12 +627,58 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@zeit/schemas": {
       "version": "2.36.0",
@@ -856,6 +1181,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -882,6 +1214,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eastasianwidth": {
@@ -968,6 +1310,39 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1098,6 +1473,279 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -1220,6 +1868,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -1293,6 +1960,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -1327,6 +2043,29 @@
       },
       "bin": {
         "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
       }
     },
     "node_modules/registry-auth-token": {
@@ -1373,6 +2112,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -1402,6 +2174,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/serve": {
@@ -1512,6 +2291,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -1580,6 +2369,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tree-kill": {
@@ -1722,6 +2528,84 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "check": "tsc --noEmit",
     "clean": "node scripts/clean.ts",
     "format": "biome format --write .",
+    "dev:verifier": "vite --config apps/verifier/vite.config.ts apps/verifier",
+    "build:verifier": "vite build --config apps/verifier/vite.config.ts apps/verifier",
+    "check:verifier": "tsc --noEmit -p apps/verifier/tsconfig.json",
     "docs:build": "typedoc",
     "docs:serve": "concurrently \"serve docs\" \"typedoc --watch --preserveWatchOutput\""
   },
@@ -52,10 +55,16 @@
     "@biomejs/biome": "^2.4.9",
     "@types/debug": "^4.1.13",
     "@types/node": "^22.15.30",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "concurrently": "^9.2.1",
     "debug": "^4.4.3",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "serve": "^14.2.5",
     "typedoc": "^0.28.14",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vite": "^8.2.1"
   }
 }

--- a/scripts/check-imports.ts
+++ b/scripts/check-imports.ts
@@ -7,26 +7,32 @@ const SRC = resolve(ROOT, "src");
 const importRegex = /(?:from|import)\s+["']([^"']+)["']/g;
 const violations: string[] = [];
 
-for await (const file of glob("src/**/*.ts", { cwd: ROOT })) {
+// Apps consume the library from outside `src`, so they have no owning submodule
+// and must enter through an entry point like anyone else.
+for await (const file of glob(["src/**/*.ts", "apps/**/*.{ts,tsx}"], { cwd: ROOT })) {
   const absFile = resolve(ROOT, file);
-  const moduleOfFile = relative(SRC, absFile).split("/")[0];
+  const owner = relative(SRC, absFile).startsWith("..") ? null : relative(SRC, absFile).split("/")[0];
   const content = await readFile(absFile, "utf8");
+
   for (const match of content.matchAll(importRegex)) {
     const spec = match[1];
     if (!spec.startsWith(".")) {
       continue;
     }
-    const targetAbs = resolve(dirname(absFile), spec);
-    const relFromSrc = relative(SRC, targetAbs);
-    if (relFromSrc.startsWith("..")) {
+
+    const target = relative(SRC, resolve(dirname(absFile), spec));
+    if (target.startsWith("..")) {
       continue;
     }
-    const targetModule = relFromSrc.split("/")[0];
-    if (targetModule === moduleOfFile) {
+
+    const targetModule = target.split("/")[0];
+    if (owner !== null && targetModule === owner) {
       continue;
     }
-    if (relFromSrc !== `${targetModule}/main.ts`) {
-      violations.push(`${file}: imports "${spec}" — cross-submodule imports must target ../${targetModule}/main.ts`);
+
+    // Either the package entry (`src/main.ts`) or a submodule's (`src/<mod>/main.ts`).
+    if (target !== "main.ts" && target !== `${targetModule}/main.ts`) {
+      violations.push(`${file}: imports "${spec}" — must target src/main.ts or ../${targetModule}/main.ts`);
     }
   }
 }

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -287,7 +287,8 @@ export class Controller {
 
   async processMessage(message: Message): Promise<void> {
     if (message.version.protocol === "ACDC") {
-      // TODO: verify ACDC credential SAID and anchors in TEL or KEL
+      // TODO: verify ACDC credential SAID and anchors in TEL or KEL, via
+      // verifyCredentialSaid / verifyCredential from core/main.ts
       this.#log.debug("processMessage: saving ACDC", { d: message.body.d });
       this.#storage.saveMessage(message);
       return;
@@ -315,7 +316,8 @@ export class Controller {
       case "vcp":
       case "iss":
       case "rev":
-        // TODO: verify is anchored to a valid ixn in the issuer's KEL
+        // TODO: verify is anchored to a valid ixn in the issuer's KEL, via
+        // verifyTransactionEventAnchor from core/main.ts
         this.#log.debug("processMessage: saving registry event", { t: message.body.t, d: message.body.d });
         this.#storage.saveMessage(message);
         break;

--- a/src/core/credential-verification.test.ts
+++ b/src/core/credential-verification.test.ts
@@ -1,0 +1,367 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import { Message, parse } from "../cesr/main.ts";
+import type { Credential, CredentialBody } from "./credential.ts";
+import { createCredential } from "./credential.ts";
+import type { IssueEventBody } from "./credential-event.ts";
+import { issue, revoke } from "./credential-event.ts";
+import type { CheckStatus, CredentialCheckId, CredentialVerification } from "./credential-verification.ts";
+import { verifyCredential, verifyCredentials } from "./credential-verification.ts";
+import { EventIndex } from "./event-index.ts";
+import { incept, interact, type KeyEvent } from "./key-event.ts";
+import { KeyEventLog } from "./key-event-log.ts";
+import { generateKeyPair } from "./keys.ts";
+import { incept as registry } from "./registry-event.ts";
+import { sign as signRaw } from "./sign.ts";
+
+const SCHEMA = "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao";
+const OTHER_SCHEMA = "ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY";
+const DT = "2026-01-01T00:00:00.000000+00:00";
+const CREDENTIAL = "EKBG6wNsN9iT_gujAjOytqAyQdwtA24qc5C96xgu6Qy9";
+
+function statuses(result: CredentialVerification): [CredentialCheckId, CheckStatus][] {
+  return result.checks.map((check) => [check.id, check.status]);
+}
+
+function status(result: CredentialVerification, id: CredentialCheckId): CheckStatus | undefined {
+  return result.checks.find((check) => check.id === id)?.status;
+}
+
+function detail(result: CredentialVerification, id: CredentialCheckId): string {
+  return result.checks.find((check) => check.id === id)?.detail ?? "";
+}
+
+async function fixtureMessages(name: string): Promise<Message[]> {
+  const bytes = new Uint8Array(await readFile(new URL(`../../fixtures/${name}`, import.meta.url)));
+  return Array.fromAsync(parse(bytes));
+}
+
+/** The fixture index, optionally with its ACDC body rewritten in place. */
+async function fixtureIndex(mutate?: (body: CredentialBody) => CredentialBody): Promise<EventIndex> {
+  const messages = await fixtureMessages("credential.cesr");
+  if (!mutate) {
+    return new EventIndex(messages);
+  }
+
+  return new EventIndex(
+    messages.map((message) =>
+      message.version.protocol === "ACDC"
+        ? new Message(mutate(structuredClone(message.body as CredentialBody)), message.attachments)
+        : message,
+    ),
+  );
+}
+
+/**
+ * An issuer with a registry, able to issue chained and revoked credentials.
+ * keripy has never produced a `rev` or edge fixture for this repo, so those
+ * paths are covered for self-consistency only.
+ */
+function newIssuer() {
+  const key = generateKeyPair();
+  const next = generateKeyPair();
+  const sign = (event: KeyEvent) => [signRaw(event.raw, { key: key.privateKey, index: 0 })];
+
+  const icp = incept({ signingKeys: [key.publicKey], nextKeys: [next.publicKeyDigest] });
+  const icpMessage = new Message(icp.body, { ControllerIdxSigs: sign(icp) });
+  const messages: Message[] = [icpMessage];
+  let log = KeyEventLog.empty().append(icpMessage);
+
+  const anchor = (seal: { i: string; s: string; d: string }) => {
+    const ixn = interact(log.state, { data: seal });
+    const message = new Message(ixn.body, { ControllerIdxSigs: sign(ixn) });
+    log = log.append(message);
+    messages.push(message);
+    return { snu: ixn.body.s, digest: ixn.body.d };
+  };
+
+  const vcp = registry({ ii: log.state.identifier });
+  messages.push(
+    new Message(vcp.body, { SealSourceCouples: [anchor({ i: vcp.body.i, s: vcp.body.s, d: vcp.body.d })] }),
+  );
+
+  return {
+    aid: log.state.identifier,
+    registry: vcp.body.i,
+    messages,
+
+    issue(args: { schema?: string; edges?: Record<string, unknown> } = {}) {
+      const credential = createCredential({
+        i: log.state.identifier,
+        ri: vcp.body.i,
+        s: args.schema ?? SCHEMA,
+        a: { i: log.state.identifier, dt: DT, LEI: "123123123" },
+        r: {},
+        ...(args.edges && { e: args.edges }),
+      });
+
+      const iss = issue({ i: credential.body.d, ri: vcp.body.i, dt: DT });
+      const couple = anchor({ i: iss.body.i, s: iss.body.s, d: iss.body.d });
+      messages.push(credential, new Message(iss.body, { SealSourceCouples: [couple] }));
+
+      return { credential, iss };
+    },
+
+    revoke(credential: Credential, iss: Message<IssueEventBody>) {
+      const rev = revoke({ i: credential.body.d, ri: vcp.body.i, p: iss.body.d });
+      const couple = anchor({ i: rev.body.i, s: rev.body.s, d: rev.body.d });
+      messages.push(new Message(rev.body, { SealSourceCouples: [couple] }));
+      return rev;
+    },
+  };
+}
+
+describe(basename(import.meta.url), () => {
+  test("should verify a keripy issued credential end to end", async () => {
+    const result = verifyCredential(await fixtureIndex(), CREDENTIAL);
+
+    assert.deepEqual(statuses(result), [
+      ["acdc-said", "passed"],
+      ["acdc-section-saids", "passed"],
+      ["issuer-kel", "passed"],
+      ["registry-inception", "passed"],
+      ["registry-anchor", "passed"],
+      ["issuance", "passed"],
+      ["issuance-anchor", "passed"],
+      ["revocation-anchor", "not-applicable"],
+      ["edges", "not-applicable"],
+      ["schema", "unchecked"],
+    ]);
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "issued");
+    assert.equal(result.issuedAt, "2025-04-17T21:53:17.019676+00:00");
+    assert.equal(result.revokedAt, null);
+    assert.equal(result.issuee, "EOdUAG4xgTpDeV8eMf1aZuFmaSOjMvDRcdpvAO48TM9A");
+    assert.deepEqual(result.edges, []);
+  });
+
+  // The schema document cannot be resolved offline, so this must never read as passed.
+  test("should never report the schema check as passed", async () => {
+    const result = verifyCredential(await fixtureIndex(), CREDENTIAL);
+
+    assert.equal(status(result, "schema"), "unchecked");
+    assert.equal(result.ok, true);
+  });
+
+  test("should verify every credential in the index", async () => {
+    const results = verifyCredentials(await fixtureIndex());
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].said, CREDENTIAL);
+  });
+
+  test("should throw for a said that is not in the index", async () => {
+    const index = await fixtureIndex();
+
+    assert.throws(() => verifyCredential(index, "EUnknown"), TypeError);
+  });
+
+  test("should fail both said checks when an attribute is altered", async () => {
+    const index = await fixtureIndex((body) => {
+      (body.a as Record<string, unknown>).LEI = "999999999";
+      return body;
+    });
+
+    const result = verifyCredential(index, CREDENTIAL);
+
+    assert.equal(result.ok, false);
+    assert.equal(status(result, "acdc-said"), "failed");
+    assert.equal(status(result, "acdc-section-saids"), "failed");
+    assert.match(detail(result, "acdc-section-saids"), /Section 'a' SAID mismatch/);
+  });
+
+  test("should fail only the body said when a top level field is altered", async () => {
+    const index = await fixtureIndex((body) => ({ ...body, s: OTHER_SCHEMA }));
+
+    const result = verifyCredential(index, CREDENTIAL);
+
+    assert.equal(status(result, "acdc-said"), "failed");
+    assert.equal(status(result, "acdc-section-saids"), "passed");
+  });
+
+  test("should skip the anchor checks when the issuer kel does not verify", async () => {
+    const messages = await fixtureMessages("credential.cesr");
+    const index = new EventIndex(
+      messages.map((message) => (message.body.t === "icp" ? new Message(message.body) : message)),
+    );
+
+    const result = verifyCredential(index, CREDENTIAL);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, "unknown");
+    assert.equal(result.issuerState, null);
+    assert.equal(status(result, "issuer-kel"), "failed");
+    assert.equal(status(result, "registry-anchor"), "skipped");
+    assert.equal(status(result, "issuance-anchor"), "skipped");
+  });
+
+  test("should fail when the issuer has no key events in the index", async () => {
+    const messages = await fixtureMessages("credential.cesr");
+    const index = new EventIndex(messages.filter((message) => message.body.t !== "icp" && message.body.t !== "ixn"));
+
+    const result = verifyCredential(index, CREDENTIAL);
+
+    assert.equal(status(result, "issuer-kel"), "failed");
+    assert.match(detail(result, "issuer-kel"), /No key events for issuer/);
+  });
+
+  // A stream that simply omits the issuance must not compute as verified.
+  test("should fail when no transaction events are present", async () => {
+    const messages = await fixtureMessages("credential.cesr");
+    const index = new EventIndex(
+      messages.filter(
+        (message) => message.version.protocol !== "KERI" || message.body.t === "icp" || message.body.t === "ixn",
+      ),
+    );
+
+    const result = verifyCredential(index, CREDENTIAL);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, "unknown");
+    assert.equal(status(result, "registry-inception"), "failed");
+    assert.equal(status(result, "issuance"), "failed");
+    assert.equal(status(result, "issuance-anchor"), "skipped");
+  });
+
+  test("should not throw on tampered input", async () => {
+    const tampered = await fixtureIndex((body) => {
+      (body.a as Record<string, unknown>).LEI = "999999999";
+      return body;
+    });
+    const bare = new EventIndex(
+      (await fixtureMessages("credential.cesr")).filter((m) => m.version.protocol === "ACDC"),
+    );
+
+    assert.doesNotThrow(() => verifyCredential(tampered, CREDENTIAL));
+    assert.doesNotThrow(() => verifyCredential(bare, CREDENTIAL));
+  });
+
+  test("should report a revoked credential as authentic but revoked", () => {
+    const issuer = newIssuer();
+    const { credential, iss } = issuer.issue();
+    issuer.revoke(credential, iss);
+
+    const result = verifyCredential(new EventIndex(issuer.messages), credential.body.d);
+
+    assert.equal(status(result, "revocation-anchor"), "passed");
+    assert.equal(result.status, "revoked");
+    assert.equal(result.ok, true);
+    assert.ok(result.revokedAt);
+  });
+
+  test("should fail the revocation when it chains to the wrong issuance", () => {
+    const issuer = newIssuer();
+    const { credential, iss } = issuer.issue();
+    const rev = issuer.revoke(credential, iss);
+
+    const messages = issuer.messages.map((message) =>
+      message.body.d === rev.body.d ? new Message({ ...rev.body, p: iss.body.i }, message.attachments) : message,
+    );
+    const result = verifyCredential(new EventIndex(messages), credential.body.d);
+
+    assert.equal(status(result, "revocation-anchor"), "failed");
+    assert.equal(result.status, "revoked");
+    assert.equal(result.ok, false);
+  });
+
+  describe("edges", () => {
+    test("should resolve a chained credential against the same index", () => {
+      const issuer = newIssuer();
+      const { credential: qvi } = issuer.issue({ schema: SCHEMA });
+      const { credential: le } = issuer.issue({
+        schema: OTHER_SCHEMA,
+        edges: { qvi: { n: qvi.body.d, s: SCHEMA } },
+      });
+
+      const results = verifyCredentials(new EventIndex(issuer.messages));
+      const byId = new Map(results.map((r) => [r.said, r]));
+
+      assert.equal(results.length, 2);
+      assert.equal(byId.get(qvi.body.d)?.ok, true);
+      assert.equal(status(byId.get(qvi.body.d) as CredentialVerification, "edges"), "not-applicable");
+
+      const leResult = byId.get(le.body.d) as CredentialVerification;
+      assert.equal(leResult.ok, true);
+      assert.equal(status(leResult, "edges"), "passed");
+      assert.deepEqual(leResult.edges, [{ label: "qvi", said: qvi.body.d, ok: true }]);
+    });
+
+    test("should fail when an edge references a credential outside the index", () => {
+      const issuer = newIssuer();
+      const { credential: qvi } = issuer.issue();
+      const { credential: le } = issuer.issue({ edges: { qvi: { n: qvi.body.d } } });
+
+      // Drop the referenced credential from the stream.
+      const messages = issuer.messages.filter((message) => message.body.d !== qvi.body.d);
+      const result = verifyCredential(new EventIndex(messages), le.body.d);
+
+      assert.equal(result.ok, false);
+      assert.equal(status(result, "edges"), "failed");
+      assert.match(detail(result, "edges"), /not in the stream/);
+      assert.deepEqual(result.edges, [{ label: "qvi", said: qvi.body.d, ok: false }]);
+    });
+
+    test("should fail when an edge declares a different schema than the credential it names", () => {
+      const issuer = newIssuer();
+      const { credential: qvi } = issuer.issue({ schema: SCHEMA });
+      const { credential: le } = issuer.issue({ edges: { qvi: { n: qvi.body.d, s: OTHER_SCHEMA } } });
+
+      const result = verifyCredential(new EventIndex(issuer.messages), le.body.d);
+
+      assert.equal(status(result, "edges"), "failed");
+      assert.match(detail(result, "edges"), /declares schema/);
+    });
+
+    test("should fail when an edge references a revoked credential", () => {
+      const issuer = newIssuer();
+      const { credential: qvi, iss } = issuer.issue();
+      const { credential: le } = issuer.issue({ edges: { qvi: { n: qvi.body.d } } });
+      issuer.revoke(qvi, iss);
+
+      const result = verifyCredential(new EventIndex(issuer.messages), le.body.d);
+
+      assert.equal(status(result, "edges"), "failed");
+      assert.match(detail(result, "edges"), /revoked/);
+    });
+
+    test("should fail when an edge references a credential that does not verify", () => {
+      const issuer = newIssuer();
+      const { credential: qvi } = issuer.issue();
+      const { credential: le } = issuer.issue({ edges: { qvi: { n: qvi.body.d } } });
+
+      // Break the referenced credential without changing the SAID it is indexed by.
+      const messages = issuer.messages.map((message) =>
+        message.body.d === qvi.body.d
+          ? new Message({ ...(message.body as CredentialBody), ri: "EOtherRegistry" }, message.attachments)
+          : message,
+      );
+      const result = verifyCredential(new EventIndex(messages), le.body.d);
+
+      assert.equal(status(result, "edges"), "failed");
+      assert.match(detail(result, "edges"), /did not verify/);
+    });
+
+    // Real SAIDs cannot form a cycle, but hand-crafted input can; this proves the
+    // walk terminates rather than recursing forever.
+    test("should fail rather than recurse when edges form a cycle", () => {
+      const issuer = newIssuer();
+      const { credential: first } = issuer.issue();
+      const { credential: second } = issuer.issue({ edges: { back: { n: first.body.d } } });
+
+      const messages = issuer.messages.map((message) =>
+        message.body.d === first.body.d
+          ? new Message(
+              { ...(message.body as CredentialBody), e: { d: "x", fwd: { n: second.body.d } } },
+              message.attachments,
+            )
+          : message,
+      );
+      const result = verifyCredential(new EventIndex(messages), second.body.d);
+
+      assert.equal(status(result, "edges"), "failed");
+      assert.match(detail(result, "edges"), /did not verify|cycle/);
+    });
+  });
+});

--- a/src/core/credential-verification.ts
+++ b/src/core/credential-verification.ts
@@ -1,0 +1,381 @@
+import type { Message } from "../cesr/main.ts";
+import type { CredentialBody } from "./credential.ts";
+import { credentialIssuee, verifyCredentialSaid } from "./credential.ts";
+import type { IssueEventBody, RevokeEventBody } from "./credential-event.ts";
+import type { EventIndex } from "./event-index.ts";
+import type { KeyState } from "./key-event.ts";
+import { KeyEventLog } from "./key-event-log.ts";
+import type { RegistryInceptEventBody } from "./registry-event.ts";
+import type { CredentialStatus, TransactionEventBody } from "./transaction-event-log.ts";
+import {
+  resolveCredentialTel,
+  verifyTransactionEventAnchor,
+  verifyTransactionEventSaid,
+} from "./transaction-event-log.ts";
+import type { VerifyResult } from "./verify.ts";
+
+export type CheckStatus =
+  | "passed"
+  | "failed"
+  /** A prerequisite check failed, so this one could not be evaluated. */
+  | "skipped"
+  /** Nothing in the input triggers this check. */
+  | "not-applicable"
+  /** Out of scope for offline verification. */
+  | "unchecked";
+
+export type CredentialCheckId =
+  | "acdc-said"
+  | "acdc-section-saids"
+  | "issuer-kel"
+  | "registry-inception"
+  | "registry-anchor"
+  | "issuance"
+  | "issuance-anchor"
+  | "revocation-anchor"
+  | "edges"
+  | "schema";
+
+export interface CredentialCheck {
+  id: CredentialCheckId;
+  status: CheckStatus;
+  /** Always set unless the status is "passed". */
+  detail?: string;
+}
+
+/** An `e` block entry, resolved against the credentials in the same index. */
+export interface CredentialEdge {
+  /** The edge's label in the `e` block, e.g. "qvi". */
+  label: string;
+  /** SAID of the credential the edge points at. */
+  said: string;
+  /** Whether that credential is present in the index and verified. */
+  ok: boolean;
+}
+
+export interface CredentialVerification {
+  credential: Message<CredentialBody>;
+  said: string;
+  issuer: string;
+  /** The AID the credential was issued to, when the attribute section names one. */
+  issuee: string | null;
+  registry: string;
+  schema: string;
+  /** Null when the issuer KEL did not verify. */
+  issuerState: KeyState | null;
+  issuedAt: string | null;
+  revokedAt: string | null;
+  status: CredentialStatus;
+  /** Resolved `e` block entries, empty when the credential has no edges. */
+  edges: CredentialEdge[];
+  /** No check is "failed" or "skipped". Revocation is reported by `status`, not here. */
+  ok: boolean;
+  /** Every `CredentialCheckId`, always present, in display order. */
+  checks: CredentialCheck[];
+}
+
+/**
+ * Verify every credential carried by `index`, each exactly once.
+ *
+ * Issuer KELs are verified once per AID and shared across credentials, and an
+ * edge referencing another credential in the same index resolves against the
+ * result computed for it here.
+ */
+export function verifyCredentials(index: EventIndex): CredentialVerification[] {
+  const context = newContext(index);
+  return index.credentials.map((credential) => resolve(context, credential.body.d) as CredentialVerification);
+}
+
+/**
+ * Verify one credential in `index` by SAID.
+ *
+ * Throws only on malformed input — a credential that fails verification is a
+ * normal result, reported through `checks`.
+ */
+export function verifyCredential(index: EventIndex, said: string): CredentialVerification {
+  const result = resolve(newContext(index), said);
+  if (!result) {
+    throw new TypeError(`No credential ${said} in index`);
+  }
+  return result;
+}
+
+interface Context {
+  index: EventIndex;
+  logs: Map<string, KeyEventLog | string>;
+  results: Map<string, CredentialVerification>;
+  visiting: Set<string>;
+}
+
+function newContext(index: EventIndex): Context {
+  return { index, logs: new Map(), results: new Map(), visiting: new Set() };
+}
+
+/** Verified KEL for `aid`, or the reason it could not be built. Cached per run. */
+function issuerLog(context: Context, aid: string): KeyEventLog | string {
+  const cached = context.logs.get(aid);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const keyEvents = context.index.keyEvents(aid);
+  let result: KeyEventLog | string;
+  if (keyEvents.length === 0) {
+    result = `No key events for issuer ${aid}`;
+  } else {
+    try {
+      // Non-empty input means every event was appended, so `state` is populated.
+      result = KeyEventLog.fromMessages(keyEvents);
+    } catch (error) {
+      result = describe(error);
+    }
+  }
+
+  context.logs.set(aid, result);
+  return result;
+}
+
+function resolve(context: Context, said: string): CredentialVerification | null {
+  const cached = context.results.get(said);
+  if (cached) {
+    return cached;
+  }
+
+  const credential = context.index.credential(said);
+  if (!credential) {
+    return null;
+  }
+
+  const result = verify(context, credential);
+  context.results.set(said, result);
+  return result;
+}
+
+function verify(context: Context, credential: Message<CredentialBody>): CredentialVerification {
+  const body = credential.body;
+
+  if (credential.version.protocol !== "ACDC") {
+    throw new TypeError(`Not an ACDC message: protocol=${credential.version.protocol}`);
+  }
+  if (typeof body.d !== "string" || typeof body.i !== "string" || typeof body.ri !== "string") {
+    throw new TypeError("Malformed ACDC: 'd', 'i' and 'ri' must be strings");
+  }
+
+  const tel = resolveCredentialTel(context.index.transactionEvents(body.ri), {
+    credential: body.d,
+    registry: body.ri,
+  });
+
+  const said = verifyCredentialSaid(body);
+  const checks: CredentialCheck[] = [
+    toCheck("acdc-said", said.body),
+    said.sections
+      ? toCheck("acdc-section-saids", said.sections)
+      : { id: "acdc-section-saids", status: "not-applicable", detail: "No section is disclosed" },
+  ];
+
+  // The index groups key events by their own `i`, so a log found for `body.i`
+  // belongs to the issuer by construction — there is no binding left to check.
+  const log = issuerLog(context, body.i);
+  const issuer = typeof log === "string" ? null : log;
+  checks.push(
+    typeof log === "string"
+      ? { id: "issuer-kel", status: "failed", detail: log }
+      : { id: "issuer-kel", status: "passed" },
+  );
+
+  const registryCheck: CredentialCheck = tel.registry
+    ? toCheck("registry-inception", verifyRegistryInception(tel.registry.body, body))
+    : { id: "registry-inception", status: "failed", detail: `No vcp event for registry ${body.ri}` };
+  checks.push(registryCheck);
+  checks.push(anchorCheck("registry-anchor", tel.registry, issuer, registryCheck));
+
+  const issuanceCheck: CredentialCheck = tel.issuance
+    ? toCheck("issuance", verifyIssuance(tel.issuance.body, body, credential))
+    : { id: "issuance", status: "failed", detail: `No iss event for credential ${body.d}` };
+  checks.push(issuanceCheck);
+
+  const issuanceAnchorCheck = anchorCheck("issuance-anchor", tel.issuance, issuer, issuanceCheck);
+  checks.push(issuanceAnchorCheck);
+
+  checks.push(verifyRevocation(tel.revocation, tel.issuance, issuer));
+
+  const { edges, check: edgeCheck } = verifyEdges(context, body);
+  checks.push(edgeCheck);
+
+  checks.push({ id: "schema", status: "unchecked", detail: "Schema document is not available offline" });
+
+  const issued = issuanceCheck.status === "passed" && issuanceAnchorCheck.status === "passed";
+  const status: CredentialStatus = tel.status === "issued" && !issued ? "unknown" : tel.status;
+
+  return {
+    credential,
+    said: body.d,
+    issuer: body.i,
+    issuee: credentialIssuee(body),
+    registry: body.ri,
+    schema: body.s,
+    issuerState: issuer?.state ?? null,
+    issuedAt: tel.issuance?.body.dt ?? null,
+    revokedAt: tel.revocation?.body.dt ?? null,
+    status,
+    edges,
+    ok: checks.every((c) => c.status !== "failed" && c.status !== "skipped"),
+    checks,
+  };
+}
+
+interface EdgeRef {
+  label: string;
+  n: string;
+  s?: string;
+}
+
+/**
+ * Resolve each `e` entry against the index. An edge is satisfied when the
+ * credential it names is present, verifies, and matches the schema the edge
+ * declares.
+ */
+function verifyEdges(context: Context, body: CredentialBody): { edges: CredentialEdge[]; check: CredentialCheck } {
+  const id: CredentialCheckId = "edges";
+  const refs = edgeRefs(body);
+
+  if (refs.length === 0) {
+    return { edges: [], check: { id, status: "not-applicable", detail: "Credential has no edges" } };
+  }
+
+  const edges: CredentialEdge[] = [];
+  const failures: string[] = [];
+  context.visiting.add(body.d);
+
+  for (const ref of refs) {
+    let ok = false;
+
+    if (context.visiting.has(ref.n)) {
+      failures.push(`'${ref.label}' forms a cycle back to ${ref.n}`);
+    } else {
+      const target = resolve(context, ref.n);
+      if (!target) {
+        failures.push(`'${ref.label}' references ${ref.n}, which is not in the stream`);
+      } else if (ref.s !== undefined && target.schema !== ref.s) {
+        failures.push(`'${ref.label}' declares schema ${ref.s}, but ${ref.n} uses ${target.schema}`);
+      } else if (!target.ok) {
+        failures.push(`'${ref.label}' references ${ref.n}, which did not verify`);
+      } else if (target.status === "revoked") {
+        failures.push(`'${ref.label}' references ${ref.n}, which is revoked`);
+      } else {
+        ok = true;
+      }
+    }
+
+    edges.push({ label: ref.label, said: ref.n, ok });
+  }
+
+  context.visiting.delete(body.d);
+
+  return {
+    edges,
+    check: failures.length === 0 ? { id, status: "passed" } : { id, status: "failed", detail: failures.join("; ") },
+  };
+}
+
+function edgeRefs(body: CredentialBody): EdgeRef[] {
+  const section = body.e as unknown;
+  if (typeof section !== "object" || section === null) {
+    return [];
+  }
+
+  const refs: EdgeRef[] = [];
+  for (const [label, value] of Object.entries(section as Record<string, unknown>)) {
+    // `d` is the section SAID and `o` an operator, neither is an edge.
+    if (label === "d" || label === "o" || typeof value !== "object" || value === null) {
+      continue;
+    }
+    const edge = value as Record<string, unknown>;
+    if (typeof edge.n === "string") {
+      refs.push({ label, n: edge.n, s: typeof edge.s === "string" ? edge.s : undefined });
+    }
+  }
+
+  return refs;
+}
+
+const NO_KEL = "Issuer KEL did not verify";
+
+function anchorCheck(
+  id: CredentialCheckId,
+  event: Message<TransactionEventBody> | null,
+  issuer: KeyEventLog | null,
+  prerequisite: CredentialCheck,
+): CredentialCheck {
+  if (issuer === null) {
+    return { id, status: "skipped", detail: NO_KEL };
+  }
+  if (event === null || prerequisite.status !== "passed") {
+    return { id, status: "skipped", detail: `${prerequisite.id} did not verify` };
+  }
+  return toCheck(id, verifyTransactionEventAnchor(event, issuer));
+}
+
+function toCheck(id: CredentialCheckId, result: VerifyResult): CredentialCheck {
+  return result.ok ? { id, status: "passed" } : { id, status: "failed", detail: result.error };
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function verifyRegistryInception(vcp: RegistryInceptEventBody, body: CredentialBody): VerifyResult {
+  const said = verifyTransactionEventSaid(vcp);
+  if (!said.ok) {
+    return said;
+  }
+  if (vcp.ii !== body.i) {
+    return { ok: false, error: `Registry ${vcp.i} is owned by ${vcp.ii}, not by issuer ${body.i}` };
+  }
+  return { ok: true };
+}
+
+function verifyIssuance(iss: IssueEventBody, body: CredentialBody, credential: Message<CredentialBody>): VerifyResult {
+  const said = verifyTransactionEventSaid(iss);
+  if (!said.ok) {
+    return said;
+  }
+
+  // The ACDC's own seal source triple names the TEL event it belongs to. Checking
+  // it rules out a valid iss event for a different credential being substituted.
+  for (const triple of credential.attachments.SealSourceTriples) {
+    if (triple.prefix === body.d && triple.digest !== iss.d) {
+      return { ok: false, error: `Credential references issuance ${triple.digest}, but ${iss.d} was presented` };
+    }
+  }
+
+  return { ok: true };
+}
+
+function verifyRevocation(
+  revocation: Message<RevokeEventBody> | null,
+  issuance: Message<IssueEventBody> | null,
+  issuer: KeyEventLog | null,
+): CredentialCheck {
+  const id: CredentialCheckId = "revocation-anchor";
+
+  if (!revocation) {
+    return { id, status: "not-applicable", detail: "No revocation event presented" };
+  }
+
+  const said = verifyTransactionEventSaid(revocation.body);
+  if (!said.ok) {
+    return { id, status: "failed", detail: said.error };
+  }
+
+  if (issuance && revocation.body.p !== issuance.body.d) {
+    return {
+      id,
+      status: "failed",
+      detail: `Revocation prior is ${revocation.body.p}, issuance is ${issuance.body.d}`,
+    };
+  }
+
+  return anchorCheck(id, revocation, issuer, { id, status: "passed" });
+}

--- a/src/core/credential.ts
+++ b/src/core/credential.ts
@@ -1,6 +1,7 @@
 import { Message, VersionString } from "../cesr/main.ts";
-import { encodeEvent } from "./events.ts";
+import { DUMMY_SAID, encodeEvent, verifyEventSaid } from "./events.ts";
 import { saidify } from "./said.ts";
+import type { VerifyResult } from "./verify.ts";
 
 export interface CredentialBodyInit {
   /**
@@ -96,6 +97,84 @@ export type CredentialBody = {
 
 export type Credential = Message<CredentialBody>;
 
+export interface CredentialSaidResult {
+  /**
+   * Whether the top level `d` recomputes over the body.
+   */
+  body: VerifyResult;
+
+  /**
+   * Whether each disclosed `a` / `e` / `r` block's `d` recomputes over that
+   * block, or null when the credential discloses no section to recompute.
+   */
+  sections: VerifyResult | null;
+}
+
+const SECTION_LABELS = ["a", "e", "r"];
+
+// `d` is the section SAID, `i` the issuee, `dt` the issuance date and `u` the
+// blinding nonce — none of them claims the issuer is asserting.
+const ATTRIBUTE_METADATA = ["d", "i", "dt", "u"];
+
+function attributes(body: CredentialBody): Record<string, unknown> | null {
+  const section = body.a as unknown;
+  // Compact and partially disclosed credentials carry a bare SAID string here.
+  return typeof section === "object" && section !== null ? (section as Record<string, unknown>) : null;
+}
+
+/** The claims an ACDC asserts, with the attribute section's metadata removed. */
+export function disclosedAttributes(body: CredentialBody): [string, unknown][] {
+  return Object.entries(attributes(body) ?? {}).filter(([key]) => !ATTRIBUTE_METADATA.includes(key));
+}
+
+/** The AID the credential was issued to, when the attribute section names one. */
+export function credentialIssuee(body: CredentialBody): string | null {
+  const value = attributes(body)?.i;
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Inverse of {@link createCredential}. The two must stay in lockstep.
+ *
+ * For an expanded credential the top level digest already covers the section
+ * contents, so `sections` is not an additional integrity check — it localises a
+ * failure to the section that changed, which a single top level mismatch cannot.
+ */
+export function verifyCredentialSaid(body: CredentialBody): CredentialSaidResult {
+  return { body: verifyEventSaid(body, { labels: ["d"], protocol: "ACDC" }), sections: verifySectionSaids(body) };
+}
+
+function verifySectionSaids(body: CredentialBody): VerifyResult | null {
+  let disclosed = false;
+
+  for (const label of SECTION_LABELS) {
+    const section = (body as Record<string, unknown>)[label];
+
+    // A compact or partially disclosed section is a bare SAID string with nothing to recompute.
+    if (section === undefined || typeof section === "string") {
+      continue;
+    }
+
+    if (typeof section !== "object" || section === null || Array.isArray(section)) {
+      return { ok: false, error: `Section '${label}' is not an object` };
+    }
+
+    disclosed = true;
+    const block = section as Record<string, unknown>;
+    if (typeof block.d !== "string") {
+      return { ok: false, error: `Section '${label}' has no SAID` };
+    }
+
+    // Spread first so `d` keeps its original key position; JSON.stringify is order sensitive.
+    const recomputed = saidify({ ...block, d: DUMMY_SAID }, ["d"]);
+    if (recomputed.d !== block.d) {
+      return { ok: false, error: `Section '${label}' SAID mismatch: expected ${String(recomputed.d)}, got ${block.d}` };
+    }
+  }
+
+  return disclosed ? { ok: true } : null;
+}
+
 export function createCredential(data: CredentialBodyInit): Credential {
   const body = encodeEvent<CredentialBody>({
     v: VersionString.encode({
@@ -103,20 +182,14 @@ export function createCredential(data: CredentialBodyInit): Credential {
       kind: "JSON",
       legacy: true,
     }),
-    d: "#".repeat(44),
+    d: DUMMY_SAID,
     ...(data.u && { u: data.u }),
     i: data.i,
     ri: data.ri,
     s: data.s,
-    a: saidify(
-      {
-        d: "#".repeat(44),
-        ...data.a,
-      },
-      ["d"],
-    ),
-    ...(data.e && { e: saidify({ d: "#".repeat(44), ...data.e }, ["d"]) }),
-    r: saidify({ d: "#".repeat(44), ...data.r }, ["d"]),
+    a: saidify({ d: DUMMY_SAID, ...data.a }, ["d"]),
+    ...(data.e && { e: saidify({ d: DUMMY_SAID, ...data.e }, ["d"]) }),
+    r: saidify({ d: DUMMY_SAID, ...data.r }, ["d"]),
   });
 
   return new Message<CredentialBody>(body);

--- a/src/core/event-index.test.ts
+++ b/src/core/event-index.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import { parse } from "../cesr/main.ts";
+import { EventIndex } from "./event-index.ts";
+
+const ISSUER = "EAK1H-RJM-mRzgNa7oNTv71FBvJERCHLunYI9ja9KW7w";
+const REGISTRY = "EEXV71avZSL6fKJnQky_oxHqRPlNYR3zNGD-OpJe0DJa";
+const CREDENTIAL = "EKBG6wNsN9iT_gujAjOytqAyQdwtA24qc5C96xgu6Qy9";
+
+async function fixture(name: string): Promise<Uint8Array> {
+  return new Uint8Array(await readFile(new URL(`../../fixtures/${name}`, import.meta.url)));
+}
+
+async function messages(name: string) {
+  return Array.fromAsync(parse(await fixture(name)));
+}
+
+describe(basename(import.meta.url), () => {
+  test("should index the credential fixture by identifier and registry", async () => {
+    const index = await EventIndex.parse(await fixture("credential.cesr"));
+
+    assert.deepEqual(index.identifiers, [ISSUER]);
+    assert.deepEqual(index.registries, [REGISTRY]);
+    assert.deepEqual(
+      index.credentials.map((c) => c.body.d),
+      [CREDENTIAL],
+    );
+  });
+
+  test("should group key events and registry events under their identifiers", async () => {
+    const index = await EventIndex.parse(await fixture("credential.cesr"));
+
+    assert.deepEqual(
+      index.keyEvents(ISSUER).map((event) => event.body.t),
+      ["icp", "ixn", "ixn"],
+    );
+    assert.deepEqual(
+      index.transactionEvents(REGISTRY).map((event) => event.body.t),
+      ["vcp", "iss"],
+    );
+  });
+
+  test("should look up a credential by said", async () => {
+    const index = await EventIndex.parse(await fixture("credential.cesr"));
+
+    assert.equal(index.credential(CREDENTIAL)?.body.i, ISSUER);
+    assert.equal(index.credential("EUnknown"), null);
+  });
+
+  test("should return empty results for unknown identifiers", async () => {
+    const index = await EventIndex.parse(await fixture("credential.cesr"));
+
+    assert.deepEqual(index.keyEvents("EUnknown"), []);
+    assert.deepEqual(index.transactionEvents("EUnknown"), []);
+  });
+
+  test("should ignore duplicate events when messages are replayed", async () => {
+    const parsed = await messages("credential.cesr");
+    const index = new EventIndex([...parsed, ...parsed]);
+
+    assert.equal(index.keyEvents(ISSUER).length, 3);
+    assert.equal(index.transactionEvents(REGISTRY).length, 2);
+    assert.equal(index.credentials.length, 1);
+  });
+
+  // KeyEventLog rejects a stream carrying two unrelated AIDs, so key events are
+  // kept apart per identifier.
+  test("should keep unrelated key event logs separate", async () => {
+    const index = new EventIndex([...(await messages("credential.cesr")), ...(await messages("alice.cesr"))]);
+
+    assert.equal(index.identifiers.length, 2);
+    assert.equal(index.keyEvents(ISSUER).length, 3);
+    assert.ok(index.keyEvents(ISSUER).every((event) => event.body.i === ISSUER));
+  });
+
+  test("should sort key events by sequence number regardless of stream order", async () => {
+    const index = new EventIndex((await messages("credential.cesr")).toReversed());
+
+    assert.deepEqual(
+      index.keyEvents(ISSUER).map((event) => event.body.s),
+      ["0", "1", "2"],
+    );
+  });
+
+  // IPEX unwrapping is not implemented; grant.cesr carries its ACDC inside an
+  // exn, which this ignores. Update when IPEX lands.
+  test("should index no credentials from an IPEX grant stream", async () => {
+    const index = await EventIndex.parse(await fixture("grant.cesr"));
+
+    assert.deepEqual(index.credentials, []);
+  });
+});

--- a/src/core/event-index.ts
+++ b/src/core/event-index.ts
@@ -1,0 +1,112 @@
+import type { Message, ParseInput } from "../cesr/main.ts";
+import { parse } from "../cesr/main.ts";
+import type { CredentialBody } from "./credential.ts";
+import type { DipEventBody, KeyEventBody } from "./key-event.ts";
+import { isKelEventType } from "./key-event-log.ts";
+import type { TransactionEventBody } from "./transaction-event-log.ts";
+import { isTelEventType } from "./transaction-event-log.ts";
+
+/**
+ * The key events, registry events and credentials carried by a CESR stream,
+ * grouped by the identifiers they belong to.
+ *
+ * A stream is a bag of messages, not a credential — one can carry several
+ * credentials, several registries, and the KELs of several AIDs. Indexing them
+ * together is what lets a chained credential resolve its edges against the
+ * other credentials that arrived with it.
+ */
+export class EventIndex {
+  #keyEvents = new Map<string, Message<KeyEventBody>[]>();
+  #transactionEvents = new Map<string, Message<TransactionEventBody>[]>();
+  #credentials = new Map<string, Message<CredentialBody>>();
+
+  constructor(messages: Iterable<Message>) {
+    const seen = new Set<string>();
+
+    for (const message of messages) {
+      const digest = message.body.d;
+
+      // A replayed stream would otherwise fail on a duplicate inception event.
+      if (typeof digest === "string") {
+        if (seen.has(digest)) {
+          continue;
+        }
+        seen.add(digest);
+      }
+
+      if (isKelEventType(message.body.t)) {
+        const event = message as Message<KeyEventBody>;
+        push(this.#keyEvents, event.body.i, event);
+      } else if (isTelEventType(message.body.t)) {
+        const event = message as Message<TransactionEventBody>;
+        push(this.#transactionEvents, event.body.t === "vcp" ? event.body.i : event.body.ri, event);
+      } else if (message.version.protocol === "ACDC") {
+        const credential = message as Message<CredentialBody>;
+        this.#credentials.set(credential.body.d, credential);
+      }
+      // Everything else, `exn` included, is ignored. Unwrapping IPEX only has to
+      // add messages here; nothing downstream changes.
+    }
+
+    for (const events of this.#keyEvents.values()) {
+      events.sort((a, b) => Number.parseInt(a.body.s, 16) - Number.parseInt(b.body.s, 16));
+    }
+  }
+
+  static async parse(input: ParseInput): Promise<EventIndex> {
+    return new EventIndex(await Array.fromAsync(parse(input)));
+  }
+
+  /**
+   * Key events for `aid`, preceded by those of every delegator above it so
+   * `KeyEventLog` can verify a delegated AID's `dip` anchor.
+   */
+  keyEvents(aid: string): Message<KeyEventBody>[] {
+    const chain: Message<KeyEventBody>[] = [];
+    const visited = new Set<string>();
+    let current: string | undefined = aid;
+
+    while (current !== undefined && !visited.has(current)) {
+      visited.add(current);
+      const events = this.#keyEvents.get(current);
+      if (!events) {
+        break;
+      }
+
+      chain.push(...events);
+      const first = events[0];
+      current = first?.body.t === "dip" ? (first.body as DipEventBody).di : undefined;
+    }
+
+    return chain;
+  }
+
+  transactionEvents(registry: string): Message<TransactionEventBody>[] {
+    return this.#transactionEvents.get(registry) ?? [];
+  }
+
+  get credentials(): Message<CredentialBody>[] {
+    return Array.from(this.#credentials.values());
+  }
+
+  credential(said: string): Message<CredentialBody> | null {
+    return this.#credentials.get(said) ?? null;
+  }
+
+  get identifiers(): string[] {
+    return Array.from(this.#keyEvents.keys());
+  }
+
+  get registries(): string[] {
+    return Array.from(this.#transactionEvents.keys());
+  }
+}
+
+function push<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.push(value);
+  } else {
+    map.set(key, [value]);
+  }
+}

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,7 +1,11 @@
 import { encodeText, Matter, Message, VersionString } from "../cesr/main.ts";
 import { saidify } from "./said.ts";
+import type { VerifyResult } from "./verify.ts";
 
 export const DUMMY_VERSION = VersionString.encode({ protocol: "KERI", legacy: true, kind: "JSON" });
+
+/** Placeholder occupying a SAID field while the digest over the event is computed. */
+export const DUMMY_SAID = "#".repeat(44);
 
 export function formatDate(date: Date): string {
   return date.toISOString().replace("Z", "000+00:00");
@@ -17,14 +21,19 @@ interface EncodeEventArgs {
   legacy?: boolean;
 }
 
-export function encodeEvent<T extends Record<string, unknown>>(data: T, args: EncodeEventArgs = {}): T & { v: string } {
+export function encodeEvent<T extends Record<string, unknown>>(
+  input: T,
+  args: EncodeEventArgs = {},
+): T & { v: string } {
   const labels = args.labels ?? ["d"];
+  const data: Record<string, unknown> = { ...input };
+
   for (const label of labels) {
     if (!(label in data)) {
       throw new Error(`Input missing label '${label}'`);
     }
 
-    (data as Record<string, unknown>)[label] = "#".repeat(44);
+    data[label] = DUMMY_SAID;
   }
 
   const message = new Message({
@@ -32,6 +41,31 @@ export function encodeEvent<T extends Record<string, unknown>>(data: T, args: En
     ...data,
   });
 
-  const result = saidify(message.body, labels);
-  return result;
+  return saidify(message.body, labels) as T & { v: string };
+}
+
+export interface VerifyEventSaidArgs extends EncodeEventArgs {
+  /** Names the event in the error message, e.g. the event type. */
+  subject?: string;
+}
+
+/**
+ * Inverse of {@link encodeEvent}: recompute the SAID labels over `body` and
+ * compare them against the ones it carries.
+ */
+export function verifyEventSaid(body: Record<string, unknown>, args: VerifyEventSaidArgs = {}): VerifyResult {
+  const labels = args.labels ?? ["d"];
+  const recomputed = encodeEvent(body, args);
+  const subject = args.subject ? ` for ${args.subject}` : "";
+
+  for (const label of labels) {
+    if (recomputed[label] !== body[label]) {
+      return {
+        ok: false,
+        error: `SAID mismatch on '${label}'${subject}: expected ${String(recomputed[label])}, got ${String(body[label])}`,
+      };
+    }
+  }
+
+  return { ok: true };
 }

--- a/src/core/key-event-log.ts
+++ b/src/core/key-event-log.ts
@@ -244,6 +244,65 @@ interface KeyEventSeal {
   d?: string;
 }
 
+/** The `i`/`s`/`d` triple a seal in an anchoring event's `a` field must match. */
+export interface AnchorTarget {
+  i: string;
+  s: string;
+  d: string;
+}
+
+/** Why no anchoring event was accepted. Callers phrase their own error from it. */
+export type SealAnchorFailure =
+  | { kind: "hint-missing"; snu: string; digest: string }
+  | { kind: "hint-unanchored"; digest: string }
+  | { kind: "unanchored" };
+
+/**
+ * Find the event in `anchoring` whose `a` field carries a seal for `target`,
+ * returning null on success.
+ *
+ * A SealSourceCouple/Triple, when attached, names the anchoring event directly,
+ * and every attached one must resolve. keripy does not always transmit it, so
+ * with no hint the whole log is scanned instead.
+ *
+ * Shared by delegation (`dip`/`drt`) and registry (`vcp`/`iss`/`rev`) anchoring,
+ * which differ only in how they report failure.
+ */
+export function findSealAnchor(
+  target: AnchorTarget,
+  attachments: Attachments,
+  anchoring: { identifier: string; events: Message<KeyEventBody>[] },
+): SealAnchorFailure | null {
+  const hints = [
+    ...attachments.SealSourceCouples.map((c) => ({ snu: c.snu, digest: c.digest })),
+    ...attachments.SealSourceTriples.filter((t) => t.prefix === anchoring.identifier).map((t) => ({
+      snu: t.snu,
+      digest: t.digest,
+    })),
+  ];
+
+  const anchors = (event: Message<KeyEventBody>) => {
+    const seals = (event.body as { a?: KeyEventSeal[] }).a ?? [];
+    return seals.some((seal) => seal.i === target.i && seal.s === target.s && seal.d === target.d);
+  };
+
+  if (hints.length === 0) {
+    return anchoring.events.some(anchors) ? null : { kind: "unanchored" };
+  }
+
+  for (const hint of hints) {
+    const event = anchoring.events.find((e) => e.body.d === hint.digest && e.body.s === hint.snu);
+    if (!event) {
+      return { kind: "hint-missing", snu: hint.snu, digest: hint.digest };
+    }
+    if (!anchors(event)) {
+      return { kind: "hint-unanchored", digest: hint.digest };
+    }
+  }
+
+  return null;
+}
+
 function verifyDelegationAnchor(
   body: DipEventBody | DrtEventBody,
   attachments: Attachments,
@@ -255,41 +314,20 @@ function verifyDelegationAnchor(
     );
   }
 
-  const couples = attachments.SealSourceCouples ?? [];
-  const triples = attachments.SealSourceTriples ?? [];
-  const hints = [
-    ...couples.map((c) => ({ snu: c.snu, digest: c.digest })),
-    ...triples.filter((t) => t.prefix === body.di).map((t) => ({ snu: t.snu, digest: t.digest })),
-  ];
+  const failure = findSealAnchor(body, attachments, {
+    identifier: delegator.state.identifier,
+    events: delegator.events,
+  });
 
-  // If a SealSourceCouple/Triple is attached, use it as a hint about which
-  // delegator event carries the anchor. Otherwise scan the delegator's KEL
-  // for any event whose `a` field anchors this dip/drt — keripy's wire
-  // format relies on the verifier deriving the anchor from the delegator's
-  // KEL directly when the couple isn't transmitted.
-  const matchingSeal = (event: Message<KeyEventBody>) => {
-    const anchors = (event.body as { a?: KeyEventSeal[] }).a ?? [];
-    return anchors.some((seal) => seal.i === body.i && seal.s === body.s && seal.d === body.d);
-  };
-
-  if (hints.length > 0) {
-    for (const ref of hints) {
-      const event = delegator.events.find((e) => e.body.d === ref.digest && e.body.s === ref.snu);
-      if (!event) {
-        throw new Error(`Delegator anchor not found in KEL: s=${ref.snu} d=${ref.digest} (delegator=${body.di})`);
-      }
-      if (!matchingSeal(event)) {
-        throw new Error(
-          `Delegator event ${ref.digest} does not anchor ${body.t} ${body.d}: missing matching key-event seal in a[]`,
-        );
-      }
-    }
-    return;
-  }
-
-  const anchorEvent = delegator.events.find((e) => matchingSeal(e));
-  if (!anchorEvent) {
-    throw new Error(`No anchoring event found in delegator KEL for ${body.t} ${body.d} (delegator=${body.di})`);
+  switch (failure?.kind) {
+    case "hint-missing":
+      throw new Error(`Delegator anchor not found in KEL: s=${failure.snu} d=${failure.digest} (delegator=${body.di})`);
+    case "hint-unanchored":
+      throw new Error(
+        `Delegator event ${failure.digest} does not anchor ${body.t} ${body.d}: missing matching key-event seal in a[]`,
+      );
+    case "unanchored":
+      throw new Error(`No anchoring event found in delegator KEL for ${body.t} ${body.d} (delegator=${body.di})`);
   }
 }
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -31,17 +31,27 @@ export type {
   CredentialBodyInit,
   CredentialEdges,
   CredentialRules,
+  CredentialSaidResult,
   CredentialSubject,
 } from "./credential.ts";
-export { createCredential } from "./credential.ts";
+export { createCredential, credentialIssuee, disclosedAttributes, verifyCredentialSaid } from "./credential.ts";
 export type {
   IssueEventBody as IssueEvent,
   IssueEventInit,
   RevokeEventBody as RevokeEvent,
   RevokeEventInit,
 } from "./credential-event.ts";
+export type {
+  CheckStatus,
+  CredentialCheck,
+  CredentialCheckId,
+  CredentialEdge,
+  CredentialVerification,
+} from "./credential-verification.ts";
+export { verifyCredential, verifyCredentials } from "./credential-verification.ts";
 export type { Endpoint, EndRoleRecord, LocationRecord } from "./endpoint-discovery.ts";
 export { resolveEndRole, resolveLocation } from "./endpoint-discovery.ts";
+export { EventIndex } from "./event-index.ts";
 export type { WitnessEndpoint } from "./kawa.ts";
 export { submitToWitnesses } from "./kawa.ts";
 export type {
@@ -79,6 +89,8 @@ export type {
 export type { SignOptions } from "./sign.ts";
 export { sign } from "./sign.ts";
 export type { Threshold } from "./threshold.ts";
+export type { CredentialStatus, TransactionEventBody } from "./transaction-event-log.ts";
+export { isTelEventType, verifyTransactionEventAnchor, verifyTransactionEventSaid } from "./transaction-event-log.ts";
 export type { VerifyOptions, VerifyResult } from "./verify.ts";
 export { verifySignature } from "./verify.ts";
 

--- a/src/core/transaction-event-log.test.ts
+++ b/src/core/transaction-event-log.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { describe, test } from "node:test";
+import { Message, parse } from "../cesr/main.ts";
+import type { IssueEventBody } from "./credential-event.ts";
+import type { KeyEventBody } from "./key-event.ts";
+import { isKelEventType, KeyEventLog } from "./key-event-log.ts";
+import type { RegistryInceptEventBody } from "./registry-event.ts";
+import type { TransactionEventBody } from "./transaction-event-log.ts";
+import {
+  isTelEventType,
+  resolveCredentialTel,
+  verifyTransactionEventAnchor,
+  verifyTransactionEventSaid,
+} from "./transaction-event-log.ts";
+
+const REGISTRY = "EEXV71avZSL6fKJnQky_oxHqRPlNYR3zNGD-OpJe0DJa";
+const CREDENTIAL = "EKBG6wNsN9iT_gujAjOytqAyQdwtA24qc5C96xgu6Qy9";
+
+interface Fixture {
+  issuer: KeyEventLog;
+  vcp: Message<RegistryInceptEventBody>;
+  iss: Message<IssueEventBody>;
+}
+
+async function loadFixture(): Promise<Fixture> {
+  const bytes = new Uint8Array(await readFile(new URL("../../fixtures/credential.cesr", import.meta.url)));
+  const messages = await Array.fromAsync(parse(bytes));
+
+  const keyEvents = messages.filter((m) => isKelEventType(m.body.t)) as Message<KeyEventBody>[];
+  const vcp = messages.find((m) => m.body.t === "vcp") as Message<RegistryInceptEventBody>;
+  const iss = messages.find((m) => m.body.t === "iss") as Message<IssueEventBody>;
+
+  return { issuer: KeyEventLog.fromMessages(keyEvents), vcp, iss };
+}
+
+describe(basename(import.meta.url), () => {
+  test("should identify transaction event types", () => {
+    assert.ok(isTelEventType("vcp"));
+    assert.ok(isTelEventType("iss"));
+    assert.ok(isTelEventType("rev"));
+    assert.equal(isTelEventType("ixn"), false);
+    assert.equal(isTelEventType(undefined), false);
+  });
+
+  test("should verify the said of a keripy vcp over both d and i", async () => {
+    const { vcp } = await loadFixture();
+    assert.deepEqual(verifyTransactionEventSaid(vcp.body), { ok: true });
+  });
+
+  test("should verify the said of a keripy iss", async () => {
+    const { iss } = await loadFixture();
+    assert.deepEqual(verifyTransactionEventSaid(iss.body), { ok: true });
+  });
+
+  test("should reject a vcp whose nonce was altered", async () => {
+    const { vcp } = await loadFixture();
+    const tampered = { ...vcp.body, n: "0AAr75cmjijU8_h_MYwJAwuX" };
+
+    const result = verifyTransactionEventSaid(tampered);
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /SAID mismatch on 'd' for vcp/);
+  });
+
+  test("should reject an iss whose timestamp was altered", async () => {
+    const { iss } = await loadFixture();
+    const tampered = { ...iss.body, dt: "2026-01-01T00:00:00.000000+00:00" };
+
+    const result = verifyTransactionEventSaid(tampered);
+    assert.equal(result.ok, false);
+  });
+
+  test("should not mutate the event it verifies", async () => {
+    const { iss } = await loadFixture();
+    const before = JSON.stringify(iss.body);
+
+    verifyTransactionEventSaid(iss.body);
+
+    assert.equal(JSON.stringify(iss.body), before);
+  });
+
+  test("should verify the anchors of a keripy vcp and iss", async () => {
+    const { issuer, vcp, iss } = await loadFixture();
+
+    assert.deepEqual(verifyTransactionEventAnchor(vcp, issuer), { ok: true });
+    assert.deepEqual(verifyTransactionEventAnchor(iss, issuer), { ok: true });
+  });
+
+  test("should reject an anchor hint pointing at an event outside the issuer kel", async () => {
+    const { issuer, iss } = await loadFixture();
+    const tampered = new Message(iss.body, {
+      SealSourceCouples: [{ snu: "2", digest: "EJIHL_dGqxLeLVHg8gFTpbiQ15VoUjUGR6t0hI3ffWaX" }],
+    });
+
+    const result = verifyTransactionEventAnchor(tampered, issuer);
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /Anchoring event not in issuer KEL/);
+  });
+
+  test("should reject an anchor hint pointing at the wrong issuer event", async () => {
+    const { issuer, iss, vcp } = await loadFixture();
+    // The ixn that anchors the vcp does not anchor the iss.
+    const registryAnchor = vcp.attachments.SealSourceCouples[0];
+    const tampered = new Message(iss.body, { SealSourceCouples: [registryAnchor] });
+
+    const result = verifyTransactionEventAnchor(tampered, issuer);
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /does not anchor iss/);
+  });
+
+  // keripy does not always transmit the couple, so the anchor must still be
+  // found by scanning the issuer's KEL.
+  test("should find the anchor by scanning when no hint is attached", async () => {
+    const { issuer, iss } = await loadFixture();
+    const stripped = new Message(iss.body);
+
+    assert.deepEqual(verifyTransactionEventAnchor(stripped, issuer), { ok: true });
+  });
+
+  test("should report a missing anchor when no issuer event carries the seal", async () => {
+    const { issuer, iss } = await loadFixture();
+    const unanchored = new Message({ ...iss.body, d: "EEUs6vfVMrXAwWmJAKX1yWtQTJ6AhCIEQF1K_HEXdNLX" });
+
+    const result = verifyTransactionEventAnchor(unanchored, issuer);
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /No anchoring event in issuer KEL/);
+  });
+
+  test("should resolve the tel for the fixture credential", async () => {
+    const { vcp, iss } = await loadFixture();
+    const events: Message<TransactionEventBody>[] = [vcp, iss];
+
+    const tel = resolveCredentialTel(events, { credential: CREDENTIAL, registry: REGISTRY });
+
+    assert.equal(tel.registry?.body.d, vcp.body.d);
+    assert.equal(tel.issuance?.body.d, iss.body.d);
+    assert.equal(tel.revocation, null);
+    assert.equal(tel.status, "issued");
+  });
+
+  test("should report unknown status for a credential with no issuance", async () => {
+    const { vcp, iss } = await loadFixture();
+    const events: Message<TransactionEventBody>[] = [vcp, iss];
+
+    const tel = resolveCredentialTel(events, { credential: "EOther", registry: REGISTRY });
+
+    assert.equal(tel.issuance, null);
+    assert.equal(tel.status, "unknown");
+  });
+});

--- a/src/core/transaction-event-log.ts
+++ b/src/core/transaction-event-log.ts
@@ -1,0 +1,105 @@
+/**
+ * Verification of registry transaction events (`vcp`, `iss`, `rev`).
+ *
+ * These are functions rather than a `KeyEventLog`-style class: a TEL carries no
+ * reduced state for each event to consult, and callers need each failure
+ * reported separately rather than collapsed into a single throw.
+ *
+ * TEL events are not signed. Authenticity comes from the seal that anchors them
+ * into the issuer's signed KEL, which is what {@link verifyTransactionEventAnchor}
+ * checks.
+ */
+
+import type { Message } from "../cesr/main.ts";
+import type { IssueEventBody, RevokeEventBody } from "./credential-event.ts";
+import { verifyEventSaid } from "./events.ts";
+import type { KeyEventLog } from "./key-event-log.ts";
+import { findSealAnchor } from "./key-event-log.ts";
+import type { RegistryInceptEventBody } from "./registry-event.ts";
+import type { VerifyResult } from "./verify.ts";
+
+export type TransactionEventBody = RegistryInceptEventBody | IssueEventBody | RevokeEventBody;
+
+export type CredentialStatus = "issued" | "revoked" | "unknown";
+
+export interface CredentialTel {
+  registry: Message<RegistryInceptEventBody> | null;
+  issuance: Message<IssueEventBody> | null;
+  revocation: Message<RevokeEventBody> | null;
+  status: CredentialStatus;
+}
+
+export interface ResolveCredentialTelArgs {
+  credential: string;
+  registry: string;
+}
+
+const SAID_LABELS: Record<string, string[]> = {
+  vcp: ["d", "i"],
+  iss: ["d"],
+  rev: ["d"],
+};
+
+export function isTelEventType(t: unknown): boolean {
+  return t === "vcp" || t === "iss" || t === "rev";
+}
+
+export function verifyTransactionEventSaid(body: TransactionEventBody): VerifyResult {
+  const labels = SAID_LABELS[body.t];
+  if (!labels) {
+    return { ok: false, error: `Unsupported transaction event type: ${body.t}` };
+  }
+
+  return verifyEventSaid(body, { labels, subject: body.t });
+}
+
+export function verifyTransactionEventAnchor(
+  message: Message<TransactionEventBody>,
+  issuer: KeyEventLog,
+): VerifyResult {
+  const body = message.body;
+  const failure = findSealAnchor(body, message.attachments, {
+    identifier: issuer.state.identifier,
+    events: issuer.events,
+  });
+
+  switch (failure?.kind) {
+    case "hint-missing":
+      return { ok: false, error: `Anchoring event not in issuer KEL: s=${failure.snu} d=${failure.digest}` };
+    case "hint-unanchored":
+      return {
+        ok: false,
+        error: `Issuer event ${failure.digest} does not anchor ${body.t} ${body.d}: no matching seal in a[]`,
+      };
+    case "unanchored":
+      return { ok: false, error: `No anchoring event in issuer KEL for ${body.t} ${body.d}` };
+    default:
+      return { ok: true };
+  }
+}
+
+export function resolveCredentialTel(
+  events: Iterable<Message<TransactionEventBody>>,
+  args: ResolveCredentialTelArgs,
+): CredentialTel {
+  let registry: Message<RegistryInceptEventBody> | null = null;
+  let issuance: Message<IssueEventBody> | null = null;
+  let revocation: Message<RevokeEventBody> | null = null;
+
+  for (const message of events) {
+    const body = message.body;
+    if (body.t === "vcp" && body.i === args.registry) {
+      registry = message as Message<RegistryInceptEventBody>;
+    } else if (body.t === "iss" && body.i === args.credential && body.ri === args.registry) {
+      issuance = message as Message<IssueEventBody>;
+    } else if (body.t === "rev" && body.i === args.credential && body.ri === args.registry) {
+      revocation = message as Message<RevokeEventBody>;
+    }
+  }
+
+  // Status reflects the presence of a revocation even when that revocation fails
+  // its own checks — never report "issued" while a revocation is being claimed.
+  const status: CredentialStatus = revocation ? "revoked" : issuance ? "issued" : "unknown";
+
+  return { registry, issuance, revocation, status };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "exclude": ["dist"],
+  "exclude": ["dist", "apps"],
   "compilerOptions": {
+    "strict": true,
     "noEmit": true,
     "target": "esnext",
     "module": "nodenext",


### PR DESCRIPTION
## Context

Proves that a credential issued by KERIpy can be verified by a web app built on keri-js, with no backend. `fixtures/credential.cesr` is already real KERIpy 1.3.3 output — issuer `icp`, the anchoring `ixn`s, `vcp`, `iss`, and the ACDC — so the missing half was a verifier.

The verifier lives in `src/core/` and depends only on `src/cesr/`. It holds no keys, signs nothing, persists nothing, and makes no network calls. `Controller`, `storage/`, `witness/`, `mailbox/` and `sqlite-storage/` are untouched and unimported.

## What it does

Parsing produces a generic `EventIndex` — key events per AID, transaction events per registry, credentials by SAID. Verification resolves against that index:

```ts
const index = await EventIndex.parse(bytes);
const results = verifyCredentials(index);
```

Three things follow from indexing the whole stream rather than bundling per credential:

- A chained credential set resolves its `e` edges against the credentials that arrived in the same stream.
- Each issuer KEL is verified once, however many credentials reference it.
- Each credential is verified once, memoised by SAID.

`verifyCredential` returns a fixed ten-row checklist, never a boolean, and never throws on a verification failure — only on malformed input. Checks that could not run are `skipped` rather than `failed`. The `schema` row is permanently `unchecked`, because the schema document cannot be resolved offline; reporting it as passed would overstate what offline verification proves.

Worth knowing for anyone reading the UI: per `docs/specs/acdc.md`, TEL events and the ACDC are **not signed**. Authenticity is a chain of seals into the issuer's signed, witnessed KEL. The checklist is built around that chain, not around a signature on the credential.

## Shared rather than duplicated

- `findSealAnchor` in `key-event-log.ts` now backs both delegation and registry anchoring. It returns a structured failure reason so both callers keep their original error wording — no existing test changed.
- `verifyEventSaid` in `events.ts` backs both the credential and TEL SAID checks.
- `encodeEvent` no longer mutates its input. That removes the need for defensive cloning at every verification site, and with it a class of bug where verifying a tampered message would overwrite the evidence.

## App

`apps/verifier/` — React + Vite, importing `src/core/main.ts`. Drop a `.cesr` file, get the checklist. Production bundle is 272 kB (87 kB gzipped) and contains no controller or sqlite code.

The repo stays a single package. `scripts/check-imports.ts` now also covers `apps/`, so the demo can only enter through an entry point, and the root `tsconfig.json` excludes `apps` (the app has its own config with DOM and JSX).

## Notable removals

`issuer-binding` was dropped as a check. The index groups key events by their own `i`, so a log found for the credential's issuer belongs to that issuer by construction — the check could only ever be green or skipped, never red, and an always-green row in an honesty-focused checklist is misleading.

## Also in here

- `strict: true` on the root tsconfig. The repo already passed with it; `CLAUDE.md` claimed it was on and it was not. Flagging it because it's a repo-wide contract change riding in a feature PR.
- The Deno CI steps dropped `--conditions=keri-source`, dead since 98c7a4f, and are now scoped to `src test_vectors` so app tests are not discovered by Deno.
- `npm run check:verifier` added to CI — nothing type-checked the app before.

## Test plan

- `npm test` — 523 pass, 0 fail. 26 new: 8 for `EventIndex`, 18 for verification including 6 edge cases (chain resolves, target missing, schema mismatch, target revoked, target invalid, cycle terminates).
- `npm run lint`, `npm run check`, `npm run check:verifier`, `npm run build`, `npm run build:verifier` — all clean.
- Verified `fixtures/credential.cesr` end to end: all eight substantive checks pass, `schema` unchecked, status `issued`. Witness receipts are verified as part of the KEL check.
- Confirmed the extended import rule rejects a deep import (`src/core/key-event-log.ts`) and accepts both `src/main.ts` and `src/core/main.ts`.
- Confirmed the production bundle contains no `Controller`, `MailboxClient`, or `node:sqlite` code.
- Server-rendered `CredentialResult` against the fixture to confirm the UI shows real data; that scaffolding was removed before commit.

**Unverified**

- No click-through in a real browser. The app is type-checked, builds, and its components render correctly under SSR, but drag-and-drop and the paste field were not exercised interactively.
- Revocation and edges have no KERIpy-generated fixture, so both are covered by synthetic scenarios built from this repo's own event builders. That proves self-consistency, not interop — the `rev` and edge wire formats are taken from `docs/specs/acdc.md`. Tracked in #34.

## Known issue, not introduced here

Concatenated CESR streams mis-parse when the last message has ungrouped attachments: `alice.cesr` doubled parses fine, `credential.cesr` doubled throws `Unknown code {"v"`. The ACDC's trailing `-IAB` seal-source-triple is not length-wrapped, so the attachment reader runs past the message boundary. It only works today because the ACDC happens to be last in the stream. Pre-existing in the parser; the app surfaces parse failures as an error rather than crashing.
