### PR TITLE
docs: cut CLAUDE.md content the repo already states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,8 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
 KERI-JS is a TypeScript implementation of KERI (Key Event Receipt Infrastructure), a cryptographic key management and identity framework. It is a pnpm workspace publishing two packages.
-
-### Repository layout
-
-```
-packages/cesr/     "cesr"  — cesr/, encoding/
-packages/keri/     "keri"  — core/, controller/, storage/, logging/,
-                             sqlite-storage/, witness/, mailbox/, nodejs-utils/, cli/
-apps/verifier/     private React app
-test_consumer/     public-surface tests, run under Node and Deno
-test_interop/      KERIpy compatibility tests
-fixtures/          .cesr fixtures shared by both packages' tests
-```
 
 Each submodule has a `main.ts` that defines its public surface. Within a package, cross-submodule imports must target `../<submodule>/main.ts` — never reach into another submodule's internal files. Across packages, and from anything outside `packages/*/src`, use the package name (`cesr`, `cesr/encoding`, `keri`, `keri/witness`, …). Both rules are enforced by `scripts/check-imports.ts`, run as part of `pnpm run lint`.
 
@@ -27,31 +13,13 @@ Workspace members are declared in `pnpm-workspace.yaml`, and sibling dependencie
 ## Commands
 
 ```sh
-pnpm run build           # Build both packages to packages/*/dist
-pnpm run test            # Unit tests (packages/*/src/**/*.test.ts)
-pnpm run check           # TypeScript type-check (no emit)
-pnpm run lint            # Biome lint + import boundary check
-pnpm run format          # Biome formatting (write)
-
-pnpm run test:consumer   # Public-surface tests through package names
-pnpm run test:vector     # Cross-impl test vectors (packages/cesr/test_vectors/)
-pnpm run test:interop    # Interop tests (requires .venv with KERIpy)
-
-pnpm run dev:verifier                       # Watch-build the library alongside the Vite dev server
 pnpm --filter @keri-js/verifier run check   # Type-check the app (needs a full `pnpm install`)
 ```
-
-Tests use the native Node.js test runner. Unit test files live alongside source files.
-
-Jobs that do not build the verifier app install with `pnpm install --frozen-lockfile --filter "./packages/*"`, which keeps React and Vite out of the store and the virtual store entirely. The `verifier` job uses a bare `pnpm install`.
 
 pnpm's isolated `node_modules` means an undeclared dependency fails rather than resolving through hoisting. Anything imported from `scripts/`, `test_interop/` or `test_consumer/` must be declared in the root `package.json`.
 
 ## TypeScript & Code Style
 
-- `strict: true` enabled
-- Build output goes to `packages/*/dist`
-- Biome handles linting and formatting (`biome.json` at root)
 - Cryptography uses `@noble/*` libraries exclusively
 - Both packages publish `dist` **and** `src`, and their `exports` carry a `deno` condition pointing at the TypeScript source:
 


### PR DESCRIPTION
## Context

`CLAUDE.md` loads into context at the start of every session in this repo. Several sections restated facts that `package.json`, `ls`, `.github/workflows/` and `README.md` already carry, so they cost tokens every session without telling a reader anything the codebase doesn't.

## Proposal

Remove the derivable blocks (32 lines, 4590 → 2955 chars):

- Repository layout tree — `ls` and `packages/*/package.json`
- The command list — every entry is a `package.json` script and is already in README.md's Development section. Kept the one line README doesn't have: `pnpm --filter @keri-js/verifier run check` needs a full `pnpm install`
- "Tests use the native Node.js test runner" — the `test` script is `node --test`
- The CI install-filter paragraph — verbatim in `.github/workflows/{ci,docs,publish}`
- `strict: true` / dist output / "Biome handles linting" bullets — `tsconfig.base.json` and `biome.json`
- The "This file provides guidance to Claude Code" preamble

## Out of scope

Kept everything the code can't teach: import boundaries, the `workspace:*` protocol note, build-before-check, pnpm's isolated `node_modules`, `@noble/*`, the `deno` export condition and its rationale, and the `docs/specs/` pointers.