### PR TITLE
fix: keep vite output visible during dev:verifier

### DIFF
--- a/packages/cesr/package.json
+++ b/packages/cesr/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
-    "dev": "tsc -p tsconfig.build.json --watch",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "check": "tsc --noEmit"
   }
 }

--- a/packages/keri/package.json
+++ b/packages/keri/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
-    "dev": "tsc -p tsconfig.build.json --watch",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Context

`pnpm run dev:verifier` runs two `tsc --watch` processes alongside vite. `tsc --watch` clears the terminal before each recompile, which wipes vite's startup banner — including the dev server URL.

## Proposal

- Add `--preserveWatchOutput` to the `dev` script in `packages/cesr` and `packages/keri`, so tsc appends its status lines instead of clearing.

## Test plan

- Ran `pnpm run dev` in `packages/cesr` with output redirected to a file: watch lines present, no terminal-clear escape sequences.

**Unverified**

- The redirected run was non-TTY, where tsc would not clear regardless. The user confirmed the vite URL now stays visible in an interactive `pnpm run dev:verifier`.