### PR TITLE
ci: deploy the verifier app to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,60 @@
+name: Deploy Verifier
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      # Full install: the verifier is an apps/* member, so the --filter "./packages/*" form skips it.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Build verifier app
+        run: pnpm --filter @keri-js/verifier run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: "apps/verifier/dist"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,8 +37,9 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
+      # --base only here: Pages serves the app under /keri-js/, local dev serves it at the root.
       - name: Build verifier app
-        run: pnpm --filter @keri-js/verifier run build
+        run: pnpm --filter @keri-js/verifier run build --base=/keri-js/
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/apps/verifier/vite.config.ts
+++ b/apps/verifier/vite.config.ts
@@ -2,5 +2,6 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  base: "/keri-js/",
   plugins: [react()],
 });

--- a/apps/verifier/vite.config.ts
+++ b/apps/verifier/vite.config.ts
@@ -2,6 +2,5 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "/keri-js/",
   plugins: [react()],
 });


### PR DESCRIPTION
Closes #46.

## Context

Pages serves `lenkan.dev/keri-js` but nothing deploys there since the API docs workflow was removed. The verifier is a static SPA, so it fits that slot.

## Changes

- `.github/workflows/pages.yaml`, on push to `main`. It mirrors the removed `docs.yaml` (same `pages` concurrency group, same build/deploy job split) and runs a full `pnpm install` instead of `--filter "./packages/*"`, since the verifier is an `apps/*` member.
- The build step passes `--base=/keri-js/`. Without a base the build emits absolute asset paths that resolve to `lenkan.dev/assets/…` and 404 under the project path. Keeping it on the command instead of in `vite.config.ts` leaves local dev serving the app at the root.

## Test plan

- `pnpm --filter @keri-js/verifier run build --base=/keri-js/` — `dist/index.html` references `/keri-js/assets/index-*.js` and `/keri-js/assets/index-*.css`. pnpm forwards the flag to vite without a `--` separator.
- `pnpm --filter @keri-js/verifier run build` — unchanged, emits `/assets/…`.
- `vite` dev server — `GET /` returns 200.

### Unverified

- The deploy itself. The workflow only runs on `main`.