### PR TITLE
ci: pin actions to digests and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -50,13 +50,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -72,13 +72,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -88,7 +88,7 @@ jobs:
 
       # No build step: the `deno` export condition points at src, so Deno never reads dist.
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
         with:
           deno-version: "2"
 
@@ -100,13 +100,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -128,13 +128,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -143,7 +143,7 @@ jobs:
         run: pnpm install --frozen-lockfile --filter "./packages/*"
 
       - name: Setup python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           cache: "pip"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -42,10 +42,10 @@ jobs:
         run: pnpm --filter @keri-js/verifier run build --base=/keri-js/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "apps/verifier/dist"
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Context

Workflow steps referenced actions by mutable tags (`actions/checkout@v6`, `pnpm/action-setup@v4`, …), so a compromised or retargeted tag would run in CI and in the publishing job that holds `NPM_TOKEN` and `id-token: write`.

## Proposal

- Update every action to its latest release and pin it to that release's commit SHA, with the version kept as a trailing comment.

  | Action | Was | Now | SHA |
  |---|---|---|---|
  | actions/checkout | v6 | v7.0.1 | `3d3c42e5` |
  | pnpm/action-setup | v4 | v6.0.10 | `0977fd99` |
  | actions/setup-node | v6 | v7.0.0 | `82076278` |
  | denoland/setup-deno | v2 | v2.0.5 | `22d081ff` |
  | actions/setup-python | v6 | v7.0.0 | `5fda3b95` |
  | actions/configure-pages | v6 | v6.0.0 | `45bfe019` |
  | actions/upload-pages-artifact | v4 | v5.0.0 | `fc324d35` |
  | actions/deploy-pages | v5 | v5.0.0 | `cd2ce8fc` |

- Add `.github/dependabot.yml`: weekly `github-actions` updates, all actions grouped into a single PR. Dependabot bumps both the SHA and the version comment.

Majors worth calling out:

- `pnpm/action-setup` v6 is the release that adds pnpm 11 support; the repo pins `pnpm@11.21.0` in `packageManager`.
- `setup-node` v7 moves to ESM and drops a dummy `NODE_AUTH_TOKEN` export. `publish.yml` sets `NODE_AUTH_TOKEN` itself from `secrets.NPM_TOKEN`, so it is unaffected.
- `upload-pages-artifact` v5 bumps its internal `upload-artifact` to v7 and adds an `include-hidden-files` input; no input this workflow uses changed.

## Out of scope

- Dependabot for npm dependencies.
- Adding a workflow linter to `pnpm run lint`.

## Test plan

- Verified each pinned SHA against its tag with `git ls-remote` (annotated tags dereferenced with `^{}`).

**Unverified**

- Workflow YAML was not linted locally — no `actionlint` or PyYAML available in the environment. `publish.yml` and `pages.yaml` only run on `main` and tags, so this PR's CI run does not exercise them.
