### PR TITLE
build: emit declaration maps

### DIFF
--- a/packages/cesr/tsconfig.build.json
+++ b/packages/cesr/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "noEmit": false,
     "rewriteRelativeImportExtensions": true,

--- a/packages/keri/tsconfig.build.json
+++ b/packages/keri/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "noEmit": false,
     "rewriteRelativeImportExtensions": true,


### PR DESCRIPTION
## Context

Both packages already publish `src` next to `dist` — the `deno` export condition needs it, and `sourceMap: true` makes runtime stack traces point at it. But nothing connected the declarations to that source, so **Go to Definition** on an imported symbol landed in `dist/**/*.d.ts` rather than the `.ts` file it came from.

## Proposal

- Add `"declarationMap": true` to `packages/cesr/tsconfig.build.json` and `packages/keri/tsconfig.build.json`.

Each `.d.ts` gains a `//# sourceMappingURL=` footer and a sibling `.d.ts.map`:

```json
{"file":"matter.d.ts","sources":["../../src/cesr/matter.ts"], ...}
```

`files` already ships all of `dist` and all of `src` minus tests, so the maps and their targets are both in the tarball with no manifest change. Editors that resolve the map jump to the source; anything that ignores it falls back to the declaration as before.

Tarball growth is one map per declaration:

| Package | Files before | Files after | `.d.ts.map` |
|---|---:|---:|---:|
| `cesr` | 79 | 98 | 19 |
| `keri` | 195 | 243 | 48 |

## Out of scope

- Pointing the `types` condition at `src` instead of `dist`. That would break consumers: the source uses `.ts`-extension relative imports (required by `rewriteRelativeImportExtensions`), so any consumer without `allowImportingTsExtensions` gets `TS5097` on every import, and `skipLibCheck` cannot suppress it because these are `.ts` files, not `.d.ts`. Declaration maps get editor navigation to source without putting the implementation in the consumer's program.

## Test plan

- `tsc -b packages/keri/tsconfig.build.json --force` — clean; verified `dist/cesr/matter.d.ts.map` resolves to `../../src/cesr/matter.ts` and the `.d.ts` carries the `sourceMappingURL` footer
- `tsc --noEmit` (root project) — clean
- `node --test 'packages/*/src/**/*.test.ts'` — 523 pass, 0 fail
- `node --test 'packages/cesr/test_vectors/**/*.test.ts'` — 892 pass, 0 fail
- `node --test 'test_consumer/**/*.test.ts'` — 7 pass, 0 fail
- `deno test --allow-net --allow-read test_consumer` — 5 passed (7 steps)
- `biome check packages scripts test_consumer test_interop` — 140 files, clean; `node scripts/check-imports.ts` — clean
- `npm pack --dry-run` in both packages — counts in the table above, still zero `*.test.ts`

**Unverified**

- `pnpm run lint` at the root fails locally on stale `.claude/worktrees/*/biome.json` copies being picked up as nested root configs. Unrelated to this change and not present in CI, which is why the two lint commands were run directly instead.
- `pnpm run test:interop` — `pip install -r requirements.txt` fails locally building `lmdb` on Python 3.14.
