### PR TITLE
chore: replace deprecated biome recommended field with preset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noConsole": "error"
       },


### PR DESCRIPTION
## Context

Biome 2.5.8 warns on every lint run that `linter.rules.recommended` is deprecated and will be removed in the next major version. `biome.json:20` is the only place the field is used.

## Proposal

- Replace `"recommended": true` with `"preset": "recommended"` in `biome.json`.

## Out of scope

- Changing which rules are enabled, or the `suspicious`/`style` overrides.
- Upgrading Biome past the current `^2.4.9` range.

## Test plan

- `pnpm run lint` before the change: deprecation info diagnostic, 174 files checked, no other findings.
- `pnpm run lint` after the change: clean, still 174 files, no findings, no warning.
- Confirmed the preset still enables the recommended rule set — a scratch file containing `1 == "1"` still errors with `noDoubleEquals`.

Closes #39