### PR TITLE
test(interop): report failures instead of hanging the run

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest:consumer": "pnpm run build",
     "test:consumer": "node --test --no-warnings 'test_consumer/**/*.test.ts'",
     "pretest:interop": "pnpm run build",
-    "test:interop": "node --test --test-concurrency=1 --no-warnings 'test_interop/test_*.ts'",
+    "test:interop": "node --test --test-force-exit --test-concurrency=1 --no-warnings 'test_interop/test_*.ts'",
     "pretest:vector": "pnpm run build",
     "test:vector": "node --test --no-warnings 'packages/cesr/test_vectors/**/*.test.ts'",
     "lint": "biome check . && node --no-warnings scripts/check-imports.ts",

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { DatabaseSync } from "node:sqlite";
@@ -105,6 +106,16 @@ export async function startKerijsMailbox(opts: { port?: number; signal?: AbortSi
   return { aid: mailbox.aid, url, oobi: `${url}/oobi` };
 }
 
+const witnesses = new Set<ChildProcess>();
+
+// A witness that outlives the `after()` hook's SIGTERM holds its stdio pipes open, which keeps the
+// test process alive past the last test. SIGKILL is the only signal left once we are already exiting.
+process.on("exit", () => {
+  for (const child of witnesses) {
+    child.kill("SIGKILL");
+  }
+});
+
 export async function startKeripyWitness(
   opts: { port?: number; salt?: string; signal?: AbortSignal; logLevel?: string } = {},
 ): Promise<KeripyWitness> {
@@ -119,6 +130,9 @@ export async function startKeripyWitness(
   await keripy.ends.add({ eid: aid, role: "controller" });
   await keripy.location.add({ url });
   const child = keripy.witness.start({ http: httpPort, tcp: tcpPort, logLevel: opts.logLevel ?? "ERROR" });
+
+  witnesses.add(child);
+  child.once("exit", () => witnesses.delete(child));
 
   opts.signal?.addEventListener("abort", () => {
     child.kill();
@@ -141,6 +155,7 @@ export async function startKeripyWitness(
   }
 
   if (!ready) {
+    child.kill();
     throw new Error(`KERIpy witness at ${oobiUrl} did not become reachable within 30s`);
   }
 


### PR DESCRIPTION
## Context

When an interop test failed, `node --test` never exited and the job burned its Actions timeout. Because node prints failure diagnostics in its end-of-run summary, the stall also swallowed the reason the test failed.

The mechanism is a KERIpy witness that outlives the `after()` hook's `SIGTERM`. It keeps its stdio pipes open, which holds the test process alive past the last test — matching the runner's `Terminate orphan process: pid (2677) (kli)` cleanup line.

## Changes

- Add `--test-force-exit` to `test:interop` so the run always prints its summary and exits.
- Track every witness child in `startKeripyWitness` and `SIGKILL` any survivor from a `process.on("exit")` handler, so the job leaves no orphan `kli` behind.
- Kill the child when `startKeripyWitness` gives up on the 30s reachability wait — that throw previously leaked the process.

## Out of scope

- Why the challenge-response tests failed in the two runs that prompted the issue. That failure was transient.
- The `findFreePort` race, tracked separately.

## Test plan

- Reproduced the hang in a standalone repro (a failing test plus a child that survives `SIGTERM`): the run stalled with no summary until an external 20s timeout killed it, exit 124. With `--test-force-exit` the same repro reported the failure and exited in 93ms, and with the exit handler added the child was gone afterwards.
- `pnpm run test:interop` on the branch: 22/22 pass in 175s, no `kli` processes left behind.
- Induced a failure in `test_challenge_respond.ts` and ran that file: the failure printed with its full stack and summary, the run exited in 7.5s, and no orphan witness remained. Reverted the induced failure.
- `pnpm run check` and `pnpm run lint` both pass.

Closes #51
