### PR TITLE
fix: stop handing duplicate ports to KERIpy witnesses

### DIFF
--- a/test_interop/keripy.ts
+++ b/test_interop/keripy.ts
@@ -7,6 +7,12 @@ import { fileURLToPath } from "node:url";
 import debug, { type Debugger } from "debug";
 
 const KLI = join(dirname(fileURLToPath(import.meta.url)), "..", ".venv/bin/kli");
+const TIMEOUT = 20000;
+const TAIL = 2000;
+
+function format(args: string[]): string {
+  return `kli ${args.map((arg) => (arg.includes(" ") ? `"${arg}"` : arg)).join(" ")}`;
+}
 
 export class KERIPy {
   readonly name: string;
@@ -34,25 +40,40 @@ export class KERIPy {
   }
 
   private run(args: string[]): Promise<string> {
-    this.log(`kli ${args.map((arg) => (arg.includes(" ") ? `"${arg}"` : arg)).join(" ")}`);
+    const command = format(args);
+    this.log(command);
     return new Promise((resolve, reject) => {
-      const child = spawn(KLI, args, { timeout: 20000 });
+      const child = spawn(KLI, args, { timeout: TIMEOUT });
+      // `output` is what callers parse, so it stays stdout-only; `tail` is both streams, for the
+      // error message. `kli` reports a failed resolve on stdout and the traceback on stderr.
       let output = "";
+      let tail = "";
+      const append = (chunk: Buffer) => {
+        tail = (tail + chunk.toString()).slice(-TAIL);
+      };
+
       child.stdout.on("data", (d: Buffer) => {
         const message = d.toString();
         this.log(message);
         output += message;
+        append(d);
       });
-      child.stderr.on("data", (d: Buffer) => this.log(d.toString()));
+      child.stderr.on("data", (d: Buffer) => {
+        this.log(d.toString());
+        append(d);
+      });
       child.on("error", (err) => {
         reject(err);
       });
-      child.on("close", (code) => {
-        if (code !== 0) {
-          reject(new Error(`kli ${args[0]} failed`));
-        } else {
+      // `close` rather than `exit`, so the tail has everything the process wrote before it died.
+      child.on("close", (code, signal) => {
+        if (code === 0) {
           resolve(output.trim());
+          return;
         }
+
+        const reason = code === null ? `killed (${signal}) after ${TIMEOUT}ms` : `exited (code=${code})`;
+        reject(new Error(`${command} ${reason}: ${tail.trim().replaceAll("\n", " ") || "<no output>"}`));
       });
     });
   }

--- a/test_interop/keripy.ts
+++ b/test_interop/keripy.ts
@@ -1,5 +1,5 @@
 import type { Buffer } from "node:buffer";
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -173,7 +173,12 @@ export class KERIPy {
   };
 
   witness = {
-    start: (opts: { http: number; tcp: number; logLevel?: string; signal?: AbortSignal }): ChildProcess => {
+    start: (opts: {
+      http: number;
+      tcp: number;
+      logLevel?: string;
+      signal?: AbortSignal;
+    }): ChildProcessWithoutNullStreams => {
       const args = [
         "witness",
         "start",

--- a/test_interop/utils.ts
+++ b/test_interop/utils.ts
@@ -1,5 +1,7 @@
-import type { ChildProcess } from "node:child_process";
-import { createServer } from "node:http";
+import assert from "node:assert";
+import type { Buffer } from "node:buffer";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { DatabaseSync } from "node:sqlite";
 import { Controller } from "@keri-js/infra/controller";
@@ -26,18 +28,62 @@ export function createController() {
   return controller;
 }
 
-// Only for `startKeripyWitness`: `kli` binds its own sockets in another process, so the port has to
-// be released before it can take it. Everything served in-process uses `listen` below instead, which
-// never releases the port and so cannot lose it to whatever binds next.
-function findFreePort(): Promise<number> {
+// Remembering every port ever handed out eventually covers enough of the ephemeral range that the
+// kernel, which hands them out in order, can only offer ports already in the set. A window of recent
+// ones is what the guarantee actually needs: a port handed out this long ago is either bound or gone.
+const RECENT_PORTS = 256;
+const handedOut = new Set<number>();
+
+function rememberPort(port: number): void {
+  handedOut.add(port);
+  if (handedOut.size > RECENT_PORTS) {
+    handedOut.delete(handedOut.values().next().value as number);
+  }
+}
+
+function bindEphemeral(): Promise<{ server: Server; port: number }> {
   return new Promise((resolve, reject) => {
     const server = createServer();
-    server.listen(0, () => {
-      const { port } = server.address() as AddressInfo;
-      server.close(() => resolve(port));
-    });
+    server.listen(0, () => resolve({ server, port: (server.address() as AddressInfo).port }));
     server.on("error", reject);
   });
+}
+
+// Only for `startKeripyWitness`: `kli` binds its own sockets in another process, so the ports have to
+// be released before it can take them. Everything served in-process uses `listen` below instead,
+// which never releases the port and so cannot lose it to whatever binds next.
+//
+// The ports are held open all at once and only released together, so no two of them can be equal,
+// and `handedOut` keeps that guarantee across calls: a bind landing on a port already given away
+// stays open while it re-rolls, so the OS cannot offer it again. What survives is a race with a
+// process outside this one, which `startKeripyWitness` retries.
+const REROLLS = 10;
+
+async function allocatePorts(count: number): Promise<number[]> {
+  const held: Server[] = [];
+  const ports: number[] = [];
+
+  try {
+    while (ports.length < count) {
+      let port = 0;
+      for (let attempt = 0; attempt < REROLLS; attempt++) {
+        const bound = await bindEphemeral();
+        held.push(bound.server);
+        port = bound.port;
+        if (!handedOut.has(port)) {
+          break;
+        }
+      }
+      // A range too crowded to re-roll out of takes the repeat rather than failing: the ports of
+      // this call are still distinct from each other, and the spawn retry covers the rest.
+      rememberPort(port);
+      ports.push(port);
+    }
+  } finally {
+    await Promise.all(held.map((server) => new Promise((resolve) => server.close(resolve))));
+  }
+
+  return ports;
 }
 
 const serverLogger: Logger = {
@@ -105,7 +151,7 @@ export async function startKerijsMailbox(opts: { port?: number; signal?: AbortSi
   return { aid: mailbox.aid, url, oobi: `${url}/oobi` };
 }
 
-const witnesses = new Set<ChildProcess>();
+const witnesses = new Set<ChildProcessWithoutNullStreams>();
 
 // A witness that outlives the `after()` hook's SIGTERM holds its stdio pipes open, which keeps the
 // test process alive past the last test. SIGKILL is the only signal left once we are already exiting.
@@ -115,50 +161,110 @@ process.on("exit", () => {
   }
 });
 
+const READY_TIMEOUT = 30000;
+
+// Thrown when `kli` is gone: the ports it was given are the likely reason, so this is the one
+// failure `startKeripyWitness` retries.
+class WitnessExitedError extends Error {}
+
+// `kli` writes "cannot create http server on port N" to stdout and the traceback to stderr, so both
+// streams go into the tail.
+function watchOutput(child: ChildProcessWithoutNullStreams): { exited: Promise<number | null>; tail: () => string } {
+  let tail = "";
+  const append = (chunk: Buffer) => {
+    tail = (tail + chunk.toString()).slice(-2000);
+  };
+
+  child.stdout.on("data", append);
+  child.stderr.on("data", append);
+
+  return {
+    // `close` rather than `exit`, so the tail has everything the process wrote before it died.
+    exited: new Promise((resolve) => child.once("close", resolve)),
+    tail: () => tail.trim().replaceAll("\n", " "),
+  };
+}
+
+async function waitUntilReachable(
+  child: ChildProcessWithoutNullStreams,
+  ports: { http: number; tcp: number },
+): Promise<void> {
+  const { exited, tail } = watchOutput(child);
+  let stopped = false;
+
+  const poll = (async () => {
+    const deadline = Date.now() + READY_TIMEOUT;
+    while (Date.now() < deadline && !stopped) {
+      try {
+        const response = await fetch(`http://localhost:${ports.http}/oobi`);
+        if (response.ok || response.status === 404) {
+          return "reachable" as const;
+        }
+      } catch {
+        // not ready yet
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    return "timeout" as const;
+  })();
+
+  const outcome = await Promise.race([poll, exited.then(() => "exited" as const)]);
+  stopped = true;
+
+  const where = `KERIpy witness on :${ports.http}/:${ports.tcp}`;
+  if (outcome === "exited") {
+    throw new WitnessExitedError(
+      `${where} exited (code=${await exited}) before becoming reachable: ${tail() || "no output"}`,
+    );
+  }
+  if (outcome === "timeout") {
+    throw new Error(`${where} did not answer within ${READY_TIMEOUT / 1000}s (process still running)`);
+  }
+}
+
 export async function startKeripyWitness(
   opts: { port?: number; salt?: string; signal?: AbortSignal; logLevel?: string } = {},
 ): Promise<KeripyWitness> {
-  const httpPort = opts.port ?? (await findFreePort());
-  const tcpPort = await findFreePort();
-  const url = `http://localhost:${httpPort}`;
-
   const keripy = new KERIPy({});
   await keripy.init({ salt: opts.salt });
   await keripy.incept({ toad: 0, transferable: false });
   const aid = await keripy.aid();
   await keripy.ends.add({ eid: aid, role: "controller" });
-  await keripy.location.add({ url });
-  const child = keripy.witness.start({ http: httpPort, tcp: tcpPort, logLevel: opts.logLevel ?? "ERROR" });
 
-  witnesses.add(child);
-  child.once("exit", () => witnesses.delete(child));
-
+  let child: ChildProcessWithoutNullStreams | undefined;
   opts.signal?.addEventListener("abort", () => {
-    child.kill();
+    child?.kill();
   });
 
-  const oobiUrl = `${url}/oobi`;
-  const deadline = Date.now() + 30000;
-  let ready = false;
-  while (Date.now() < deadline) {
+  // A port the caller picked is theirs to get right, so only auto-allocated ports are worth another
+  // roll. Everything above is port-independent and stays out of the loop.
+  const attempts = opts.port === undefined ? 3 : 1;
+  for (let attempt = 1; ; attempt++) {
+    const [allocated, allocatedTcp] = await allocatePorts(opts.port === undefined ? 2 : 1);
+    const httpPort = opts.port ?? allocated;
+    const tcpPort = opts.port === undefined ? allocatedTcp : allocated;
+    assert(httpPort !== tcpPort, `KERIpy witness given the same port twice: ${httpPort}`);
+
+    const url = `http://localhost:${httpPort}`;
+    // The URL carries the http port, so every attempt re-publishes it; the newest reply wins.
+    await keripy.location.add({ url });
+    child = keripy.witness.start({ http: httpPort, tcp: tcpPort, logLevel: opts.logLevel ?? "ERROR" });
+
+    const spawned = child;
+    witnesses.add(spawned);
+    spawned.once("exit", () => witnesses.delete(spawned));
+
     try {
-      const response = await fetch(oobiUrl);
-      if (response.ok || response.status === 404) {
-        ready = true;
-        break;
+      await waitUntilReachable(child, { http: httpPort, tcp: tcpPort });
+      return { aid, url, oobi: `${url}/oobi`, kli: keripy };
+    } catch (error) {
+      child.kill();
+      if (attempt >= attempts || !(error instanceof WitnessExitedError)) {
+        throw error;
       }
-    } catch {
-      // not ready yet
+      console.warn(`[keripy] attempt ${attempt}/${attempts} failed, retrying on fresh ports: ${error.message}`);
     }
-    await new Promise((resolve) => setTimeout(resolve, 500));
   }
-
-  if (!ready) {
-    child.kill();
-    throw new Error(`KERIpy witness at ${oobiUrl} did not become reachable within 30s`);
-  }
-
-  return { aid, url, oobi: oobiUrl, kli: keripy };
 }
 
 export async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {


### PR DESCRIPTION
## Context

`findFreePort` closed its server before returning the port, so the OS was free to hand the same one to the next caller. `startKeripyWitness` calls it twice per witness and several tests start witnesses under `Promise.all`, so `kli` could be asked to bind a port another witness had already taken. It then failed to bind and the run died 30 seconds later at the readiness poll, reporting a slow witness rather than a port clash.

Closes #52.

## Proposal

- `allocatePorts(count)` replaces `findFreePort`. Every port of a call is held open at once and released only together, so no two ports from one call can be equal. A module-level window of the 256 most recently handed-out ports extends that across calls: a bind landing on one of them keeps its server open and re-rolls, up to 10 times, so the kernel cannot offer it again.
- A range too crowded to re-roll out of accepts the repeat rather than throwing. The ports of the call are still distinct from each other, and the spawn retry covers the rest — a bookkeeping heuristic should not be able to fail a test run outright.
- The readiness wait races the poll loop against the child's `close`, so the three outcomes are distinguished: reachable, `exited (code=N) before becoming reachable: <output tail>`, and `did not answer within 30s (process still running)`. `kli` writes `cannot create http server on port N` to stdout and the traceback to stderr, so the tail covers both streams.
- A spawn on auto-allocated ports retries up to three times on the exit path, allocating fresh ports and re-publishing `location add` each time. A caller-supplied port fails immediately — a port the caller chose is a real error, not a race. `init`/`incept`/`ends.add` are port-independent and stay outside the loop.
- `assert(httpPort !== tcpPort)` before spawning, and one abort listener that kills whichever child is current.
- `KERIPy.witness.start` now returns `ChildProcessWithoutNullStreams`, so the caller can read the streams without null checks.

Two behaviours were confirmed against `kli` before writing any of this: it **exits** on a bind failure (code 255, under a second) rather than hanging, which is why retry keys on exit and a genuine timeout stays a one-shot failure; and a second `location add` **supersedes** the first, so re-publishing the URL on retry is enough.

## Out of scope

- The in-process `listen` helper, which binds first and never releases the port.
- The run-hangs-on-failure behaviour, tracked separately.

## Test plan

- `pnpm run test:interop` — 22/22 pass.
- `test_witness_receipt.ts` (three concurrent witnesses) 20 consecutive rounds — 20/20 pass, 6 tests each, no retry fired.
- Allocator stress, 2000 rounds at 2, 3 and 4 concurrent witnesses — 0 duplicate ports in all three. Re-rolls fired 287 / 435 / 553 times with 0 forced repeats, so the kernel does re-offer recently released ports and the window catches it.
- Same stress under a deliberately narrowed 1000-port ephemeral range — 0 duplicates, no crash, degrading to accepted repeats as designed. Range restored afterwards.
- Failure path with an occupied port passed as `opts.port` — fails in 3.2s with `KERIpy witness on :46143/:41917 exited (code=255) before becoming reachable: … Address already in use … cannot create http server on port 46143`. No retry, no 30s wait.
- Retry path with attempt 1 stubbed onto an occupied port — warning logged, attempt 2 succeeds on fresh ports in 4.4s, and the served OOBI carries the new port, confirming the re-published location wins.
- `pnpm run lint`, `pnpm run check` — clean.

### Unverified

- The 0.10% duplicate rate from the issue did not reproduce on this machine: the old `findFreePort` also measured 0/2000 across five runs at 2, 3, 4 and 16 concurrent callers. The box is idle with the full 28k-port range, so the kernel's cursor rarely wraps onto a just-closed port. The before/after comparison the issue asks for is therefore missing; what backs the fix is the structural guarantee that simultaneously-held ports cannot be equal, plus the re-roll counts above.
